### PR TITLE
Add node_modules to filename checks

### DIFF
--- a/checks/filenames.php
+++ b/checks/filenames.php
@@ -18,19 +18,20 @@ class File_Checks implements themecheck {
 			array_push( $filenames, strtolower( basename( $php_key ) ) );
 		}
 		$blacklist = array(
-				'thumbs.db'				=> __( 'Windows thumbnail store', 'theme-check' ),
-				'desktop.ini'			=> __( 'windows system file', 'theme-check' ),
-				'project.properties'	=> __( 'NetBeans Project File', 'theme-check' ),
-				'project.xml'			=> __( 'NetBeans Project File', 'theme-check' ),
-				'\.kpf'					=> __( 'Komodo Project File', 'theme-check' ),
-				'^\.+[a-zA-Z0-9]'		=> __( 'Hidden Files or Folders', 'theme-check' ),
-				'php.ini'				=> __( 'PHP server settings file', 'theme-check' ),
-				'dwsync.xml'			=> __( 'Dreamweaver project file', 'theme-check' ),
-				'error_log'				=> __( 'PHP error log', 'theme-check' ),
-				'web.config'			=> __( 'Server settings file', 'theme-check' ),
-				'\.sql'					=> __( 'SQL dump file', 'theme-check' ),
-				'__MACOSX'				=> __( 'OSX system file', 'theme-check' )
-				);
+				'thumbs\.db'            => __( 'Windows thumbnail store', 'theme-check' ),
+				'desktop\.ini'          => __( 'windows system file', 'theme-check' ),
+				'project\.properties'   => __( 'NetBeans Project File', 'theme-check' ),
+				'project\.xml'          => __( 'NetBeans Project File', 'theme-check' ),
+				'\.kpf'                 => __( 'Komodo Project File', 'theme-check' ),
+				'^\.+[a-zA-Z0-9]'       => __( 'Hidden Files or Folders', 'theme-check' ),
+				'php\.ini'              => __( 'PHP server settings file', 'theme-check' ),
+				'dwsync\.xml'           => __( 'Dreamweaver project file', 'theme-check' ),
+				'error_log'             => __( 'PHP error log', 'theme-check' ),
+				'web\.config'           => __( 'Server settings file', 'theme-check' ),
+				'\.sql'                 => __( 'SQL dump file', 'theme-check' ),
+				'__MACOSX'              => __( 'OSX system file', 'theme-check' ),
+				'node_modules'          => __( 'Node developer files', 'theme-check' ),
+		);
 
 		$musthave = array( 'index.php', 'comments.php', 'style.css' );
 		$rechave = array( 'readme.txt' => __( 'Please see <a href="http://codex.wordpress.org/Theme_Review#Theme_Documentation">Theme_Documentation</a> for more information.', 'theme-check' ) );

--- a/main.php
+++ b/main.php
@@ -19,13 +19,21 @@ function check_main( $theme ) {
 
 	if ( $files ) {
 		foreach( $files as $key => $filename ) {
+			// Ignore . and .. files.
+			// Don't scan into node_modules or .sass-cache
+			if ( ( basename( $filename ) == '..' )
+			  || ( basename( $filename ) == '.' )
+			  || preg_match( '/node_modules\/.+/i', $filename )
+			  || preg_match( '/\.sass-cache\/.+/i', $filename )
+			){
+				continue;
+			}
+
 			if ( substr( $filename, -4 ) == '.php' ) {
 				$php[$filename] = php_strip_whitespace( $filename );
-			}
-			else if ( substr( $filename, -4 ) == '.css' ) {
+			} else if ( substr( $filename, -4 ) == '.css' ) {
 				$css[$filename] = file_get_contents( $filename );
-			}
-			else {
+			} else {
 				$other[$filename] = ( ! is_dir($filename) ) ? file_get_contents( $filename ) : '';
 			}
 		}


### PR DESCRIPTION
This also prevents scanning into `node_modules` and `.sass-cache` folders (but keeps the top-level folder for the filename check). See #4 for background.