### PR TITLE
Allow more filenames to be added to $blacklist array.

### DIFF
--- a/checks/filenames.php
+++ b/checks/filenames.php
@@ -18,19 +18,25 @@ class File_Checks implements themecheck {
 			array_push( $filenames, strtolower( basename( $php_key ) ) );
 		}
 		$blacklist = array(
-				'thumbs.db'				=> __( 'Windows thumbnail store', 'theme-check' ),
-				'desktop.ini'			=> __( 'windows system file', 'theme-check' ),
-				'project.properties'	=> __( 'NetBeans Project File', 'theme-check' ),
-				'project.xml'			=> __( 'NetBeans Project File', 'theme-check' ),
-				'\.kpf'					=> __( 'Komodo Project File', 'theme-check' ),
-				'^\.+[a-zA-Z0-9]'		=> __( 'Hidden Files or Folders', 'theme-check' ),
-				'php.ini'				=> __( 'PHP server settings file', 'theme-check' ),
-				'dwsync.xml'			=> __( 'Dreamweaver project file', 'theme-check' ),
-				'error_log'				=> __( 'PHP error log', 'theme-check' ),
-				'web.config'			=> __( 'Server settings file', 'theme-check' ),
-				'\.sql'					=> __( 'SQL dump file', 'theme-check' ),
-				'__MACOSX'				=> __( 'OSX system file', 'theme-check' )
-				);
+			'thumbs.db'				=> __( 'Windows thumbnail store', 'theme-check' ),
+			'desktop.ini'			=> __( 'windows system file', 'theme-check' ),
+			'project.properties'	=> __( 'NetBeans Project File', 'theme-check' ),
+			'project.xml'			=> __( 'NetBeans Project File', 'theme-check' ),
+			'\.kpf'					=> __( 'Komodo Project File', 'theme-check' ),
+			'^\.+[a-zA-Z0-9]'		=> __( 'Hidden Files or Folders', 'theme-check' ),
+			'php.ini'				=> __( 'PHP server settings file', 'theme-check' ),
+			'dwsync.xml'			=> __( 'Dreamweaver project file', 'theme-check' ),
+			'error_log'				=> __( 'PHP error log', 'theme-check' ),
+			'web.config'			=> __( 'Server settings file', 'theme-check' ),
+			'\.sql'					=> __( 'SQL dump file', 'theme-check' ),
+			'__MACOSX'				=> __( 'OSX system file', 'theme-check' ),
+		);
+
+		global $tc_filenames_blacklist;
+
+		if( is_array( $tc_filenames_blacklist ) && ! empty( $tc_filenames_blacklist ) ) {
+			$blacklist = array_merge( $blacklist, $tc_filenames_blacklist );
+		}
 
 		$musthave = array( 'index.php', 'comments.php', 'style.css' );
 		$rechave = array( 'readme.txt' => __( 'Please see <a href="http://codex.wordpress.org/Theme_Review#Theme_Documentation">Theme_Documentation</a> for more information.', 'theme-check' ) );


### PR DESCRIPTION
if $tc_filenames_blacklist global is an array.
Example in wp-config.php
global $tc_filenames_blacklist;
$tc_filenames_blacklist = array( 'node_modules' => 'Node Project Folder' );
