### PR TITLE
Change Plugin URI

### DIFF
--- a/lang/theme-check.pot
+++ b/lang/theme-check.pot
@@ -929,7 +929,7 @@ msgid "Theme Check"
 msgstr ""
 
 #. Plugin URI of the plugin/theme
-msgid "http://ottopress.com/wordpress-plugins/theme-check/"
+msgid "https://wordpress.org/plugins/theme-check/"
 msgstr ""
 
 #. Description of the plugin/theme

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === Theme Check ===
 Contributors: Otto42, pross
 Author URI: http://ottopress.com/
-Plugin URL: http://ottopress.com/wordpress-plugins/theme-check/
+Plugin URL: https://wordpress.org/plugins/theme-check/
 Requires at Least: 3.7
 Tested Up To: 4.1
 Tags: template, theme, check, checker, tool, wordpress, wordpress.org, upload, uploader, test, guideline, review

--- a/theme-check.php
+++ b/theme-check.php
@@ -1,7 +1,7 @@
 <?php
 /*
 Plugin Name: Theme Check
-Plugin URI: http://ottopress.com/wordpress-plugins/theme-check/
+Plugin URI: https://wordpress.org/plugins/theme-check/
 Description: A simple and easy way to test your theme for all the latest WordPress standards and practices. A great theme development tool!
 Author: Pross, Otto42
 Author URI: http://ottopress.com


### PR DESCRIPTION
I noticed Plugin URI is dead.
http://ottopress.com/wordpress-plugins/theme-check/

So I changed the URI to the plugin page.
https://wordpress.org/plugins/theme-check/

Changing the URI to the github page is also good.
https://github.com/Otto42/theme-check