### PR TITLE
Add a check for `.screen-reader-text`.

### DIFF
--- a/checks/style_needed.php
+++ b/checks/style_needed.php
@@ -22,6 +22,7 @@ class Style_Needed implements themecheck {
 			'\.wp-caption' => __( '<strong>.wp-caption</strong> css class is needed in your theme css.', 'theme-check' ),
 			'\.wp-caption-text' => __( '<strong>.wp-caption-text</strong> css class is needed in your theme css.', 'theme-check' ),
 			'\.gallery-caption' => __( '<strong>.gallery-caption</strong> css class is needed in your theme css.', 'theme-check' )
+			'\.screen-reader-text' => __( '<strong>.screen-reader-text</strong> css class is needed in your theme css. See See: <a href="http://codex.wordpress.org/CSS#WordPress_Generated_Classes">the Codex</a> for an example implementation.', 'theme-check' )
 		);
 
 		foreach ($checks as $key => $check) {


### PR DESCRIPTION
Six years ago, `.screen-reader-text` was introduced as a canonical class name for text targeted to screen readers for all of core.
Unknown to many, this includes the front-end by virtue of its use in `get_search_form()`.

To ensure forward compatibility with future a11y improvements, and be able to deal with child themes adding theme support for HTML5 features which rely on that class heavily, all themes should have it defined to deal with assistive text.

See https://core.trac.wordpress.org/ticket/29699.