### PR TITLE
Check if the file exists before opening it.

### DIFF
--- a/checkbase.php
+++ b/checkbase.php
@@ -78,6 +78,9 @@ function checkcount() {
 
 // some functions theme checks use
 function tc_grep( $error, $file ) {
+	if ( ! file_exists( $file ) ) {
+		return '';
+	}
 	$lines = file( $file, FILE_IGNORE_NEW_LINES ); // Read the theme file into an array
 	$line_index = 0;
 	$bad_lines = '';
@@ -96,6 +99,9 @@ function tc_grep( $error, $file ) {
 }
 
 function tc_preg( $preg, $file ) {
+	if ( ! file_exists( $file ) ) {
+		return '';
+	}
 	$lines = file( $file, FILE_IGNORE_NEW_LINES ); // Read the theme file into an array
 	$line_index = 0;
 	$bad_lines = '';


### PR DESCRIPTION
Can cause a PHP warning, failed to open stream: No such file or directory in themes that reference a file that is not actually there.