### PR TITLE
Add check also for `$GLOBALS['content_width']`

### DIFF
--- a/checks/content-width.php
+++ b/checks/content-width.php
@@ -10,7 +10,7 @@ class ContentWidthCheck implements themecheck {
 		// combine all the php files into one string to make it easier to search
 		$php = implode( ' ', $php_files );
 		checkcount();
-		if ( strpos( $php, '$content_width' ) === false && !preg_match( '/add_filter\(\s?("|\')embed_defaults/', $php ) && !preg_match( '/add_filter\(\s?("|\')content_width/', $php ) ) {
+		if ( strpos( $php, '$content_width' ) === false && strpos( $php, '$GLOBALS' . "['content_width']" ) === false && !preg_match( '/add_filter\(\s?("|\')embed_defaults/', $php ) && !preg_match( '/add_filter\(\s?("|\')content_width/', $php ) ) {
 			$this->error[] = '<span class="tc-lead tc-required">'.__('REQUIRED','theme-check').'</span>: '.__('No content width has been defined. Example: <pre>if ( ! isset( $content_width ) ) $content_width = 900;</pre>', 'theme-check' );
 			$ret = false;
 		}


### PR DESCRIPTION
`_s` uses now `$GLOBALS['content_width']` instead of `$content_width`

https://github.com/Automattic/_s/pull/460