### PR TITLE
Add the_post_navigation function to post navigation check.

### DIFF
--- a/checks/postsnav.php
+++ b/checks/postsnav.php
@@ -14,9 +14,10 @@ class PostPaginationCheck implements themecheck {
 		     strpos( $php, 'paginate_links' ) === false && 
 		     strpos( $php, 'the_posts_pagination' ) === false &&
 		     strpos( $php, 'the_posts_navigation' ) === false &&
+		     strpos( $php, 'the_post_navigation' ) === false &&
 		   ( strpos( $php, 'previous_posts_link' ) === false && strpos( $php, 'next_posts_link' ) === false )
 		   ) {
-			$this->error[] = '<span class="tc-lead tc-required">'.__('REQUIRED','theme-check').'</span>: '.__("The theme doesn't have post pagination code in it. Use <strong>posts_nav_link()</strong> or <strong>paginate_links()</strong> or <strong>the_posts_pagination()</strong> or <strong>the_posts_navigation()</strong> or <strong>next_posts_link()</strong> and <strong>previous_posts_link()</strong> to add post pagination.", 'theme-check' );
+			$this->error[] = '<span class="tc-lead tc-required">'.__('REQUIRED','theme-check').'</span>: '.__("The theme doesn't have post pagination code in it. Use <strong>the_post_navigation</strong> or <strong>posts_nav_link()</strong> or <strong>paginate_links()</strong> or <strong>the_posts_pagination()</strong> or <strong>the_posts_navigation()</strong> or <strong>next_posts_link()</strong> and <strong>previous_posts_link()</strong> to add post pagination.", 'theme-check' );
 			$ret = false;
 		}
 


### PR DESCRIPTION
As it stands, currently there's no check for `the_post_navigation()` (added in 4.1.0). This means that themes using this function fail the theme check. Since _s is now using this function (https://github.com/Automattic/_s/blob/master/single.php) the check should be updated to allow for this function as well.