### PR TITLE
Avoid using HTML tags in translation strings

### DIFF
--- a/checks/badthings.php
+++ b/checks/badthings.php
@@ -26,7 +26,7 @@ class Bad_Checks implements themecheck {
 					$filename = tc_filename( $php_key );
 					$error = ltrim( trim( $matches[0], '(' ) );
 					$grep = tc_grep( $error, $php_key );
-					$this->error[] = sprintf('<span class="tc-lead tc-warning">'. __( 'WARNING', 'theme-check' ) . '</span>: Found <strong>%1$s</strong> in the file <strong>%2$s</strong>. %3$s. %4$s', $error, $filename, $check, $grep );
+					$this->error[] = sprintf('<span class="tc-lead tc-warning">'. __( 'WARNING', 'theme-check' ) . '</span>: ' . __( 'Found %1$s in the file %2$s. %3$s. %4$s', 'theme-check' ), '<strong>' . $error . '</strong>', '<strong>' . $filename . '</strong>', $check, $grep );
 					$ret = false;
 				}
 			}

--- a/checks/basic.php
+++ b/checks/basic.php
@@ -31,7 +31,7 @@ class Basic_Checks implements themecheck {
 				if ( $key === 'add_theme_support\s*\(\s?("|\')automatic-feed-links("|\')\s?\)' ) $key = __( 'add_theme_support( \'automatic-feed-links\' )', 'theme-check');
 				if ( $key === 'body_class\s*\(' ) $key = __( 'body_class call in body tag', 'theme-check');
 				$key = str_replace( '\s*\(', '', $key );
-				$this->error[] = sprintf( '<span class="tc-lead tc-required">'.__('REQUIRED','theme-check').'</span>: '.__('Could not find <strong>%1$s</strong>. %2$s', 'theme-check' ), $key, $check );
+				$this->error[] = sprintf( '<span class="tc-lead tc-required">'.__('REQUIRED','theme-check').'</span>: '.__('Could not find %1$s. %2$s', 'theme-check' ), '<strong>' . $key . '</strong>', $check );
 				$ret = false;
 			}
 		}

--- a/checks/constants.php
+++ b/checks/constants.php
@@ -21,7 +21,7 @@ class Constants implements themecheck {
 					$filename = tc_filename( $php_key );
 					$error = ltrim( rtrim( $matches[0], '(' ) );
 					$grep = tc_grep( $error, $php_key );
-					$this->error[] = sprintf('<span class="tc-lead tc-recommended">'.__('RECOMMENDED','theme-check').'</span>: '.__('<strong>%1$s</strong> was found in the file <strong>%2$s</strong>. Use <strong>%3$s</strong> instead.%4$s', 'theme-check'), $error, $filename, $check, $grep );
+					$this->error[] = sprintf('<span class="tc-lead tc-recommended">'.__('RECOMMENDED','theme-check').'</span>: '.__('%1$s was found in the file %2$s. Use %3$s instead.%4$s', 'theme-check'), '<strong>' . $error . '</strong>', '<strong>' . $filename . '</strong>', '<strong>' . $check . '</strong>', $grep );
 				}
 			}
 		}

--- a/checks/filenames.php
+++ b/checks/filenames.php
@@ -40,21 +40,21 @@ class File_Checks implements themecheck {
 		foreach( $blacklist as $file => $reason ) {
 			if ( $filename = preg_grep( '/' . $file . '/', $filenames ) ) {
 				$error = implode( array_unique( $filename ), ' ' );
-				$this->error[] = sprintf('<span class="tc-lead tc-warning">'.__('WARNING','theme-check').'</span>: '.__('<strong>%1$s</strong> %2$s found.', 'theme-check'), $error, $reason) ;
+				$this->error[] = sprintf('<span class="tc-lead tc-warning">'.__('WARNING','theme-check').'</span>: '.__('%1$s %2$s found.', 'theme-check'), '<strong>' . $error . '</strong>', $reason) ;
 				$ret = false;
 			}
 		}
 
 		foreach( $musthave as $file ) {
 			if ( !in_array( $file, $filenames ) ) {
-				$this->error[] = sprintf('<span class="tc-lead tc-warning">'.__('WARNING','theme-check').'</span>: '.__('could not find the file <strong>%1$s</strong> in the theme.', 'theme-check'), $file);
+				$this->error[] = sprintf('<span class="tc-lead tc-warning">'.__('WARNING','theme-check').'</span>: '.__('Could not find the file %s in the theme.', 'theme-check'), '<strong>' . $file . '</strong>' );
 				$ret = false;
 			}
 		}
 
 		foreach( $rechave as $file => $reason ) {
 			if ( !in_array( $file, $filenames ) ) {
-				$this->error[] = sprintf('<span class="tc-lead tc-recommended">'.__('RECOMMENDED','theme-check').'</span>: '.__('could not find the file <strong>%1$s</strong> in the theme. %2$s', 'theme-check'), $file, $reason );
+				$this->error[] = sprintf('<span class="tc-lead tc-recommended">'.__('RECOMMENDED','theme-check').'</span>: '.__('Could not find the file %1$s in the theme. %2$s', 'theme-check'), '<strong>' . $file . '</strong>', $reason );
 			}
 		}
 

--- a/checks/i18n.php
+++ b/checks/i18n.php
@@ -49,8 +49,11 @@ class I18NCheck implements themecheck {
 							if ( isset( $line[0] ) ) {
 								$error = ( !strpos( $error, $line[0] ) ) ? $grep : '';
 							}
-							$this->error[] = sprintf('<span class="tc-lead tc-recommended">'.__('RECOMMENDED','theme-check').'</span>: '.__('Possible variable <strong>%1$s</strong> found in translation function in <strong>%2$s</strong>. Translation function calls must NOT contain PHP variables. %3$s','theme-check'),
-								$token[1], $filename, $error);
+							$this->error[] = sprintf('<span class="tc-lead tc-recommended">'.__('RECOMMENDED','theme-check').'</span>: '.__('Possible variable %1$s found in translation function in %2$s. Translation function calls must NOT contain PHP variables. %3$s','theme-check'),
+								'<strong>' . $token[1] . '</strong>',
+								'<strong>' . $filename . '</strong>',
+								$error
+							);
 							break; // stop looking at the tokens on this line once a variable is found
 						}
 					}

--- a/checks/iframes.php
+++ b/checks/iframes.php
@@ -17,7 +17,7 @@ class IframeCheck implements themecheck {
 					$error = ltrim( $matches[1], '(' );
 					$error = rtrim( $error, '(' );
 					$grep = tc_grep( $error, $php_key );
-					$this->error[] = sprintf('<span class="tc-lead tc-info">'.__('INFO','theme-check').'</span>: '.__('<strong>%1$s</strong> was found in the file <strong>%2$s</strong> %3$s.%4$s', 'theme-check'), $error, $filename, $check, $grep ) ;
+					$this->error[] = sprintf('<span class="tc-lead tc-info">'.__('INFO','theme-check').'</span>: '.__('%1$s was found in the file %2$s %3$s.%4$s', 'theme-check'), '<strong>' . $error . '</strong>', '<strong>' . $filename . '</strong>', $check, $grep ) ;
 				}
 			}
 		}

--- a/checks/include.php
+++ b/checks/include.php
@@ -16,7 +16,7 @@ class IncludeCheck implements themecheck {
 					$filename = tc_filename( $php_key );
 					$error = '/(?<![a-z0-9_])(?:requir|includ)e(?:_once)?\s?\(/';
 					$grep = tc_preg( $error, $php_key );
-					if ( basename($filename) !== 'functions.php' ) $this->error[] = sprintf ( '<span class="tc-lead tc-info">'.__('INFO','theme-check').'</span>: '.__('<strong>%1$s</strong> %2$s %3$s', 'theme-check' ), $filename, $check, $grep );
+					if ( basename($filename) !== 'functions.php' ) $this->error[] = sprintf ( '<span class="tc-lead tc-info">'.__('INFO','theme-check').'</span>: '.__('%1$s %2$s %3$s', 'theme-check' ), '<strong>' . $filename . '</strong>', $check, $grep );
 				}
 			}
 

--- a/checks/lineendings.php
+++ b/checks/lineendings.php
@@ -8,7 +8,7 @@ class LineEndingsCheck implements themecheck {
 			if (preg_match("/\r\n/",$phpfile)) {
 				if (preg_match("/[^\r]\n/",$phpfile)) {
 					$filename = tc_filename( $php_key );
-					$this->error[] = sprintf('<span class="tc-lead tc-warning">'.__('WARNING','theme-check').'</span>: '.__('Both DOS and UNIX style line endings were found in the file <strong>%1$s</strong>. This causes a problem with SVN repositories and must be corrected before the theme can be accepted. Please change the file to use only one style of line endings.', 'theme-check'), $filename);
+					$this->error[] = sprintf('<span class="tc-lead tc-warning">'.__('WARNING','theme-check').'</span>: '.__('Both DOS and UNIX style line endings were found in the file %1$s. This causes a problem with SVN repositories and must be corrected before the theme can be accepted. Please change the file to use only one style of line endings.', 'theme-check'), '<strong>' . $filename . '</strong>' );
 					$ret = false;
 				}
 			}
@@ -17,7 +17,7 @@ class LineEndingsCheck implements themecheck {
 			if (preg_match("/\r\n/",$cssfile)) {
 				if (preg_match("/[^\r]\n/",$cssfile)) {
 					$filename = tc_filename( $css_key );
-					$this->error[] = sprintf('<span class="tc-lead tc-warning">'.__('WARNING','theme-check').'</span>: '.__('Both DOS and UNIX style line endings were found in the file <strong>%1$s</strong>. This causes a problem with SVN repositories and must be corrected before the theme can be accepted. Please change the file to use only one style of line endings.', 'theme-check'), $filename);
+					$this->error[] = sprintf('<span class="tc-lead tc-warning">'.__('WARNING','theme-check').'</span>: '.__('Both DOS and UNIX style line endings were found in the file %1$s. This causes a problem with SVN repositories and must be corrected before the theme can be accepted. Please change the file to use only one style of line endings.', 'theme-check'), '<strong>' . $filename . '</strong>' );
 					$ret = false;
 				}
 			}
@@ -28,7 +28,7 @@ class LineEndingsCheck implements themecheck {
 				if (preg_match("/\r\n/",$othfile)) {
 					if (preg_match("/[^\r]\n/",$othfile)) {
 						$filename = tc_filename( $oth_key );
-					$this->error[] = sprintf('<span class="tc-lead tc-warning">'.__('WARNING','theme-check').'</span>: '.__('Both DOS and UNIX style line endings were found in the file <strong>%1$s</strong>. This causes a problem with SVN repositories and must be corrected before the theme can be accepted. Please change the file to use only one style of line endings.', 'theme-check'), $filename);
+					$this->error[] = sprintf('<span class="tc-lead tc-warning">'.__('WARNING','theme-check').'</span>: '.__('Both DOS and UNIX style line endings were found in the file %1$s. This causes a problem with SVN repositories and must be corrected before the theme can be accepted. Please change the file to use only one style of line endings.', 'theme-check'), '<strong>' . $filename . '</strong>' );
 						$ret = false;
 					}
 				}

--- a/checks/links.php
+++ b/checks/links.php
@@ -22,7 +22,7 @@ class Check_Links implements themecheck {
 						}
 					}
 					if ( $grep ) {
-						$this->error[] = sprintf('<span class="tc-lead tc-info">'.__('INFO','theme-check').'</span>: '.__('Possible hard-coded links were found in the file <strong>%1$s</strong>.%2$s', 'theme-check'), $filename, $grep);
+						$this->error[] = sprintf('<span class="tc-lead tc-info">'.__('INFO','theme-check').'</span>: '.__('Possible hard-coded links were found in the file %1$s.%2$s', 'theme-check'), '<strong>' . $filename . '</strong>', $grep);
 					}
 				}
 			}

--- a/checks/malware.php
+++ b/checks/malware.php
@@ -20,7 +20,7 @@ class MalwareCheck implements themecheck {
 							$error = ltrim( $match, '(' );
 							$error = rtrim( $error, '(' );
 							$grep = tc_grep( $error, $php_key );
-							$this->error[] = sprintf('<span class="tc-lead tc-warning">'.__('WARNING','theme-check').'</span>: '.__('<strong>%1$s</strong> was found in the file <strong>%2$s</strong> %3$s.%4$s', 'theme-check'), $error, $filename, $check, $grep );
+							$this->error[] = sprintf('<span class="tc-lead tc-warning">'.__('WARNING','theme-check').'</span>: '.__('%1$s was found in the file %2$s %3$s.%4$s', 'theme-check'), '<strong>' . $error. '</strong>', '<strong>' . $filename . '</strong>', $check, $grep );
 							$ret = false;
 						}
 				}

--- a/checks/more_deprecated.php
+++ b/checks/more_deprecated.php
@@ -49,7 +49,7 @@ class More_Deprecated implements themecheck {
 						$filename      = tc_filename( $php_key );
 						$error         = ltrim( rtrim( $matches[0], '(' ) );
 						$grep          = tc_grep( $error, $php_key );
-						$this->error[] = sprintf( '<span class="tc-lead tc-required">' . __( 'REQUIRED', 'theme-check' ) . '</span>: ' . __( '<strong>%1$s</strong> was found in the file <strong>%2$s</strong>. Use <strong>%3$s</strong> instead.%4$s', 'theme-check' ), $error, $filename, $replacement, $grep );
+						$this->error[] = sprintf( '<span class="tc-lead tc-required">' . __( 'REQUIRED', 'theme-check' ) . '</span>: ' . __( '%1$s was found in the file %2$s. Use %3$s instead.%4$s', 'theme-check' ), '<strong>' . $error . '</strong>', '<strong>' . $filename . '</strong>', '<strong>' . $replacement . '</strong>', $grep );
 						$ret           = false;
 					}
 				}

--- a/checks/nonprintable.php
+++ b/checks/nonprintable.php
@@ -13,7 +13,7 @@ class NonPrintableCheck implements themecheck {
 			if ( preg_match('/[\x00-\x08\x0B-\x0C\x0E-\x1F\x80-\xFF]/', $content, $matches ) ) {
 				$filename = tc_filename( $name );
 				$non_print = tc_preg( '/[\x00-\x08\x0B-\x0C\x0E-\x1F\x80-\xFF]/', $name );
-				$this->error[] = sprintf('<span class="tc-lead tc-info">'.__('INFO','theme-check').'</span>: '.__('Non-printable characters were found in the <strong>%1$s</strong> file. You may want to check this file for errors.%2$s', 'theme-check'), $filename, $non_print);
+				$this->error[] = sprintf('<span class="tc-lead tc-info">'.__('INFO','theme-check').'</span>: '.__('Non-printable characters were found in the %1$s file. You may want to check this file for errors.%2$s', 'theme-check'), '<strong>' . $filename . '</strong>', $non_print);
 			}
 		}
 

--- a/checks/phpshort.php
+++ b/checks/phpshort.php
@@ -11,7 +11,7 @@ class PHPShortTagsCheck implements themecheck {
 			if ( preg_match( '/<\?(\=?)(?!php|xml)/i', $phpfile ) ) {
 				$filename = tc_filename( $php_key );
 				$grep = tc_preg( '/<\?(\=?)(?!php|xml)/', $php_key );
-				$this->error[] = sprintf('<span class="tc-lead tc-warning">'.__('WARNING','theme-check').'</span>: '.__('Found PHP short tags in file <strong>%1$s</strong>.%2$s', 'theme-check'), $filename, $grep);
+				$this->error[] = sprintf('<span class="tc-lead tc-warning">'.__('WARNING','theme-check').'</span>: '.__('Found PHP short tags in file %1$s.%2$s', 'theme-check'), '<strong>' . $filename . '</strong>', $grep);
 				$ret = false;
 			}
 		}

--- a/checks/post-formats.php
+++ b/checks/post-formats.php
@@ -24,7 +24,7 @@ class PostFormatCheck implements themecheck {
 						$matches[0] = str_replace(array('"',"'"),'', $matches[0]);
 						$error = esc_html( rtrim($matches[0], '(' ) );
 						$grep = tc_grep( rtrim($matches[0], '(' ), $php_key);
-						$this->error[] = sprintf('<span class="tc-lead tc-required">'.__('REQUIRED','theme-check').'</span>: '.__('<strong>%1$s</strong> was found in the file <strong>%2$s</strong>. However get_post_format and/or has_post_format were not found, and no use of formats in the CSS was detected.', 'theme-check'), $error, $filename);
+						$this->error[] = sprintf('<span class="tc-lead tc-required">'.__('REQUIRED','theme-check').'</span>: '.__('%1$s was found in the file %2$s. However get_post_format and/or has_post_format were not found, and no use of formats in the CSS was detected.', 'theme-check'), '<strong>' . $error . '</strong>', '<strong>' . $filename . '</strong>');
 						$ret = false;
 					}
 				}

--- a/checks/required.php
+++ b/checks/required.php
@@ -19,7 +19,7 @@ class Required implements themecheck {
 					$matches[0] = str_replace(array('"',"'"),'', $matches[0]);
 					$error = esc_html( rtrim($matches[0], '(' ) );
 					$grep = tc_grep( rtrim($matches[0], '(' ), $php_key );
-					$this->error[] = sprintf('<span class="tc-lead tc-required">'.__('REQUIRED','theme-check').'</span>: '.__('<strong>%1$s</strong> was found in the file <strong>%2$s</strong>. Use <strong>%3$s</strong> instead.%4$s', 'theme-check'), $error, $filename, $check, $grep);
+					$this->error[] = sprintf('<span class="tc-lead tc-required">'.__('REQUIRED','theme-check').'</span>: '.__('%1$s was found in the file %2$s. Use %3$s instead.%4$s', 'theme-check'), '<strong>' . $error . '</strong>', '<strong>' . $filename . '</strong>', '<strong>' . $check . '</strong>', $grep);
 					$ret = false;
 				}
 			}

--- a/checks/screenshot.php
+++ b/checks/screenshot.php
@@ -21,7 +21,7 @@ class Screenshot_Checks implements themecheck {
 					// we have or screenshot!
 					$image = getimagesize( $other_key );
 					if ( $image[0] > 1200 || $image[1] > 900 ) {
-						$this->error[] = sprintf('<span class="tc-lead tc-recommended">'. __( 'RECOMMENDED','theme-check' ) . '</span>: ' . __( 'Screenshot is wrong size! Detected: <strong>%1$sx%2$spx</strong>. Maximum allowed size is 1200x900px.', 'theme-check' ), $image[0], $image[1]);
+						$this->error[] = sprintf('<span class="tc-lead tc-recommended">'. __( 'RECOMMENDED','theme-check' ) . '</span>: ' . __( 'Screenshot is wrong size! Detected: %1$sx%2$spx. Maximum allowed size is 1200x900px.', 'theme-check' ), '<strong>' . $image[0], $image[1] . '</strong>' );
 					}
 					if ( $image[1] / $image[0] != 0.75 ) {
 						$this->error[] = '<span class="tc-lead tc-recommended">'.__('RECOMMENDED','theme-check').'</span>: '.__('Screenshot dimensions are wrong! Ratio of width to height should be 4:3.', 'theme-check');

--- a/checks/searchform.php
+++ b/checks/searchform.php
@@ -13,7 +13,7 @@ class SearchFormCheck implements themecheck {
 				if ( preg_match( $key, $phpfile, $out ) ) {
 					$grep = tc_preg( $key, $php_key );
 					$filename = tc_filename( $php_key );
-					$this->error[] = sprintf('<span class="tc-lead tc-required">'.__('REQUIRED','theme-check').'</span>: '.__('<strong>%1$s</strong> %2$s%3$s', 'theme-check'), $filename, $check, $grep);
+					$this->error[] = sprintf('<span class="tc-lead tc-required">'.__('REQUIRED','theme-check').'</span>: '.__('%1$s %2$s%3$s', 'theme-check'), '<strong>' . $filename . '</strong>', $check, $grep);
 					$ret = false;
 				}
 			}

--- a/checks/style_suggested.php
+++ b/checks/style_suggested.php
@@ -17,7 +17,7 @@ class Style_Suggested implements themecheck {
 
 		foreach ($checks as $key => $check) {
 			if ( !preg_match( '/' . $key . '/i', $css, $matches ) ) {
-				$this->error[] = sprintf('<span class="tc-lead tc-recommended">'.__('RECOMMENDED','theme-check').'</span>: '.__('<strong>%1$s</strong> is missing from your style.css header.', 'theme-check'), $check);
+				$this->error[] = sprintf('<span class="tc-lead tc-recommended">'.__('RECOMMENDED','theme-check').'</span>: '.__('%s is missing from your style.css header.', 'theme-check'), '<strong>' . $check . '</strong>' );
 			}
 		}
 

--- a/checks/style_tags.php
+++ b/checks/style_tags.php
@@ -24,7 +24,7 @@ class Style_Tags implements themecheck {
 				if ( in_array( strtolower( $tag ), array("flexible-width","fixed-width") ) ) {
 					$this->error[] = '<span class="tc-lead tc-warning">'. __('WARNING','theme-check'). '</span>: ' . __( 'The flexible-width and fixed-width tags changed to fluid-layout and fixed-layout tags in WordPress 3.8. Additionally, the responsive-layout tag was added. Please change to using one of the new tags.', 'theme-check' );
 				} else {
-					$this->error[] = '<span class="tc-lead tc-warning">'. __('WARNING','theme-check'). '</span>: ' . sprintf(__('Found wrong tag, remove <strong>%1$s</strong> from your style.css header.', 'theme-check'), $tag);
+					$this->error[] = '<span class="tc-lead tc-warning">'. __('WARNING','theme-check'). '</span>: ' . sprintf( __('Found wrong tag, remove %s from your style.css header.', 'theme-check'), '<strong>' . $tag . '</strong>' );
 					$ret = false;
 				}
 			}

--- a/checks/suggested.php
+++ b/checks/suggested.php
@@ -31,7 +31,7 @@ class Suggested implements themecheck {
 					$matches[0] = str_replace(array('"',"'"),'', $matches[0]);
 					$error = trim( esc_html( rtrim($matches[0], '(' ) ) );
 					$grep = tc_grep( rtrim( $matches[0], '(' ), $php_key );
-					$this->error[] = sprintf('<span class="tc-lead tc-recommended">' . __( 'RECOMMENDED', 'theme-check' ) . '</span>: '. __( '<strong>%1$s</strong> was found in the file <strong>%2$s</strong>. Use <strong>%3$s</strong> instead.%4$s', 'theme-check'), $error, $filename, $check, $grep);
+					$this->error[] = sprintf('<span class="tc-lead tc-recommended">' . __( 'RECOMMENDED', 'theme-check' ) . '</span>: '. __( '%1$s was found in the file %2$s. Use %3$s instead.%4$s', 'theme-check'), '<strong>' . $error . '</strong>', '<strong>' . $filename . '</strong>', '<strong>' . $check . '</strong>', $grep);
 				}
 			}
 		}

--- a/checks/textdomain.php
+++ b/checks/textdomain.php
@@ -39,7 +39,7 @@ class TextDomainCheck implements themecheck {
 			$correct_domain = sanitize_title_with_dashes($data['Name']);
 			if ( $themename != $correct_domain ) {
 				$this->error[] = '<span class="tc-lead tc-warning">' . __( 'WARNING', 'theme-check' ) . '</span>: ' 
-					. sprintf ( __( "Your theme appears to be in the wrong directory for the theme name. The directory name must match the slug of the theme. This theme's correct slug and text-domain is <strong>%s</strong>.", 'theme-check' ), $correct_domain );
+					. sprintf ( __( "Your theme appears to be in the wrong directory for the theme name. The directory name must match the slug of the theme. This theme's correct slug and text-domain is %s.", 'theme-check' ), '<strong>' . $correct_domain . '</strong>' );
 			}
 		}
 		
@@ -86,8 +86,11 @@ class TextDomainCheck implements themecheck {
 								$new_args = $args;
 								$new_args[] = $text;
 								$this->error[] = '<span class="tc-lead tc-warning">' . __( 'WARNING', 'theme-check' ) . '</span>: ' 
-								. sprintf ( __( 'Found a translation function that has an incorrect number of arguments. Function <strong>%1$s</strong>, with the arguments <strong>%2$s</strong>', 'theme-check' ), 
-								$func, implode(', ',$new_args) );
+								. sprintf (
+									__( 'Found a translation function that has an incorrect number of arguments. Function %1$s, with the arguments %2$s', 'theme-check' ), 
+									'<strong>' . $func . '</strong>',
+									'<strong>' . implode(', ',$new_args) . '</strong>'
+								);
 							} else if ($this->rules[$func][$args_count] == 'domain') {
 								// strip quotes from the domain, avoids 'domain' and "domain" not being recognized as the same
 								$text = str_replace(array('"', "'"), '', $text);
@@ -113,8 +116,11 @@ class TextDomainCheck implements themecheck {
 					if ($in_func && 0 == $parens_balance) {
 						if (!$found_domain) {
 							$this->error[] = '<span class="tc-lead tc-warning">' . __( 'WARNING', 'theme-check' ) . '</span>: ' 
-							. sprintf ( __( 'Found a translation function that is missing a text-domain. Function <strong>%1$s</strong>, with the arguments <strong>%2$s</strong>', 'theme-check' ), 
-							$func, implode(', ',$args) );
+							. sprintf (
+								__( 'Found a translation function that is missing a text-domain. Function %1$s, with the arguments %2$s', 'theme-check' ), 
+								'<strong>' . $func . '</strong>', 
+								'<strong>' . implode(', ',$args) . '</strong>'
+							);
 						}
 						$in_func = false;
 						$func='';
@@ -133,12 +139,12 @@ class TextDomainCheck implements themecheck {
 			$this->error[] = '<span class="tc-lead tc-info">' . __( 'INFO', 'theme-check' ) . '</span>: ' 
 			. __( 'More than one text-domain is being used in this theme. This means the theme will not be compatible with WordPress.org language packs.', 'theme-check' )
 			. '<br>'
-			. sprintf( __( "The domains found are <strong>%s</strong>", 'theme-check'), $domainlist );
+			. sprintf( __( 'The domains found are %s', 'theme-check'), '<strong>' . $domainlist . '</strong>' );
 		} else {
 			$this->error[] = '<span class="tc-lead tc-info">' . __( 'INFO', 'theme-check' ) . '</span>: ' 
 			. __( "Only one text-domain is being used in this theme. Make sure it matches the theme's slug correctly so that the theme will be compatible with WordPress.org language packs.", 'theme-check' )
 			. '<br>'
-			. sprintf( __( "The domain found is <strong>%s</strong>", 'theme-check'), $domainlist );
+			. sprintf( __( 'The domain found is %s', 'theme-check'), '<strong>' . $domainlist . '</strong>' );
 			
 		}
 		

--- a/checks/time_date.php
+++ b/checks/time_date.php
@@ -19,7 +19,7 @@ class Time_Date implements themecheck {
 					$filename = tc_filename( $php_key );
 					$matches[0] = str_replace(array('"',"'"),'', $matches[0]);
 					$error = trim( esc_html( rtrim( $matches[0], '(' ) ) );
-					$this->error[] = sprintf( '<span class="tc-lead tc-info">' . __( 'INFO', 'theme-check' ) . '</span>: ' . __( "At least one hard coded date was found in the file <strong>%s</strong>. Consider get_option( 'date_format' ) instead.", 'theme-check' ), $filename );
+					$this->error[] = sprintf( '<span class="tc-lead tc-info">' . __( 'INFO', 'theme-check' ) . '</span>: ' . __( 'At least one hard coded date was found in the file %1$s. Consider %2$s instead.', 'theme-check' ), '<strong>' . $filename . '</strong>', "<strong>get_option( 'date_format' )</strong>" );
 				}
 			}
 		}

--- a/main.php
+++ b/main.php
@@ -9,7 +9,7 @@ function check_main( $theme ) {
 		// This is a child theme, so we need to pull files from the parent, which HAS to be installed.
 		$parent = get_theme_root( $data[ 'Template' ] ) . '/' . $data['Template'];
 		if ( ! tc_get_theme_data( $parent . '/style.css' ) ) { // This should never happen but we will check while were here!
-			echo '<h2>' . sprintf(__('Parent theme <strong>%1$s</strong> not found! You have to have parent AND child-theme installed!', 'theme-check'), $data[ 'Template' ] ) . '</h2>';
+			echo '<h2>' . sprintf(__('Parent theme %1$s not found! You have to have parent AND child-theme installed!', 'theme-check'), '<strong>' . $data[ 'Template' ] . '</strong>' ) . '</h2>';
 			return;
 		}
 		$parent_data = tc_get_theme_data( $parent . '/style.css' );
@@ -56,9 +56,17 @@ function check_main( $theme ) {
 
 		if ( $data[ 'Template' ] ) {
 		if ( $data['Template Version'] > $parent_data['Version'] ) {
-			echo '<p>' . sprintf(__('This child theme requires at least version <strong>%1$s</strong> of theme <strong>%2$s</strong> to be installed. You only have <strong>%3$s</strong> please update the parent theme.', 'theme-check'), $data['Template Version'], $parent_data['Title'], $parent_data['Version'] ) . '</p>';
+			echo '<p>' . sprintf(
+				__('This child theme requires at least version %1$s of theme %2$s to be installed. You only have %3$s please update the parent theme.', 'theme-check'),
+				'<strong>' . $data['Template Version'] . '</strong>',
+				'<strong>' . $parent_data['Title'] . '</strong>',
+				'<strong>' . $parent_data['Version'] . '</strong>'
+			) . '</p>';
 		}
-			echo '<p>' . sprintf(__( 'This is a child theme. The parent theme is: <strong>%1$s</strong>. These files have been included automatically!', 'theme-check'), $data[ 'Template' ] ) . '</p>';
+			echo '<p>' . sprintf(
+				__( 'This is a child theme. The parent theme is: %s. These files have been included automatically!', 'theme-check'),
+				'<strong>' . $data[ 'Template' ] . '</strong>'
+			) . '</p>';
 			if ( empty( $data['Template Version'] ) ) {
 				echo '<p>' . __('Child theme does not have the <strong>Template Version</strong> tag in style.css.', 'theme-check') . '</p>';
 			} else {
@@ -69,7 +77,13 @@ function check_main( $theme ) {
 
 		$plugins = get_plugins( '/theme-check' );
 		$version = explode( '.', $plugins['theme-check.php']['Version'] );
-		echo '<p>' . sprintf(__(' Running <strong>%1$s</strong> tests against <strong>%2$s</strong> using Guidelines Version: <strong>%3$s</strong> Plugin revision: <strong>%4$s</strong>', 'theme-check'), $checkcount, $data[ 'Title' ], $version[0], $version[1] ) . '</p>';
+		echo '<p>' . sprintf(
+			__(' Running %1$s tests against %2$s using Guidelines Version: %3$s Plugin revision: %4$s', 'theme-check'),
+			'<strong>' . $checkcount . '</strong>',
+			'<strong>' . $data[ 'Title' ] . '</strong>',
+			'<strong>' . $version[0] . '</strong>',
+			'<strong>' . $version[1] . '</strong>'
+		) . '</p>';
 		$results = display_themechecks();
 		if ( !$success ) {
 			echo '<h2>' . sprintf(__('One or more errors were found for %1$s.', 'theme-check'), $data[ 'Title' ] ) . '</h2>';


### PR DESCRIPTION
In the next version of WordPress (4.4), we fixed many translation strings that used html tags.

See: https://core.trac.wordpress.org/query?milestone=4.4&component=I18N&reporter=ramiy&group=milestone&col=id&col=summary&col=milestone&col=type&col=priority&col=component&col=severity&col=resolution&order=priority

The same thing should be done in this plugin. 

It's make it much easier to translates those strings. Removing the code, I can translate only the text.