### PR TITLE
Semicolon should be optional in wp_title()

### DIFF
--- a/checks/title.php
+++ b/checks/title.php
@@ -44,7 +44,7 @@ class Title_Checks implements themecheck {
 			
 			// First looks ahead to see of there's <title>...</title>
 			// Then performs a negative look ahead for <title> wp_title(...); </title>
-			if ( preg_match( '/(?=<title>(.*)<\/title>)(?!<title>\s*<\?php\s*wp_title\([^\)]*\);\s*\?>\s*<\/title>)/s', $file_content ) ) {
+			if ( preg_match( '/(?=<title>(.*)<\/title>)(?!<title>\s*<\?php\s*wp_title\([^\)]*\);?\s*\?>\s*<\/title>)/s', $file_content ) ) {
 				$this->error[] = '<span class="tc-lead tc-required">' . __( 'REQUIRED', 'theme-check').'</span>: ' . __( 'The <strong>&lt;title&gt;</strong> tags can only contain a call to <strong>wp_title()</strong>. Use the  <strong>wp_title filter</strong> to modify the output', 'theme-check' );
 				$ret = false;
 			}


### PR DESCRIPTION
The semicolon at the end of a call to `wp_title()` should be optional. Currently, this fails: 
````
<title><?php wp_title() ?></title>
````
Theme Check should not trigger an error for the above.