### PR TITLE
Check for Text Domain in style.css - Fixes #130

### DIFF
--- a/checks/style_needed.php
+++ b/checks/style_needed.php
@@ -14,6 +14,7 @@ class Style_Needed implements themecheck {
 			'[ \t\/*#]*Version' => __( '<strong>Version:</strong> is missing from your style.css header.', 'theme-check' ),
 			'[ \t\/*#]*License:' => __( '<strong>License:</strong> is missing from your style.css header.', 'theme-check' ),
 			'[ \t\/*#]*License URI:' => __( '<strong>License URI:</strong> is missing from your style.css header.', 'theme-check' ),
+			'[ \t\/*#]*Text Domain:' => __( '<strong>Text Domain:</strong> is missing from your style.css header.', 'theme-check' ),
 			'\.sticky' => __( '<strong>.sticky</strong> css class is needed in your theme css.', 'theme-check' ),
 			'\.bypostauthor' => __( '<strong>.bypostauthor</strong> css class is needed in your theme css.', 'theme-check' ),
 			'\.alignleft' => __( '<strong>.alignleft</strong> css class is needed in your theme css.', 'theme-check' ),


### PR DESCRIPTION
Fixes #130 I added a simple check for the presence of Text Domain: into the existing Style_Needed check. The other checks there checks that the line has the proper beginning, but doesn't validate the format of the rest of the line. This pull request mimics that, but could this be extended or is there a reason not to check the rest of the line?

If the rest of the line was checked, for checking the text domain it might be something more like
`[ \t\/*#]*Text Domain:\s*[A-Za-z0-9-]+\n`
where it confirms there is no underscore used. I haven't looked to see exactly how that's parsed yet so would do that before extending the regular expression.