### PR TITLE
Major strings cleanup and optimization

### DIFF
--- a/checkbase.php
+++ b/checkbase.php
@@ -91,7 +91,7 @@ function tc_grep( $error, $file ) {
 			$error = ltrim( $error );
 		$pre = ( FALSE !== ( $pos = strpos( $this_line, $error ) ) ? substr( $this_line, 0, $pos ) : FALSE );
 		$pre = ltrim( htmlspecialchars( $pre ) );
-			$bad_lines .= "<pre class='tc-grep'>". __("Line ", "theme-check") . ( $line_index+1 ) . ": " . $pre . htmlspecialchars( substr( stristr( $this_line, $error ), 0, 75 ) ) . "</pre>";
+			$bad_lines .= "<pre class='tc-grep'>". __("Line", "theme-check") . ' ' . ( $line_index+1 ) . ": " . $pre . htmlspecialchars( substr( stristr( $this_line, $error ), 0, 75 ) ) . "</pre>";
 		}
 		$line_index++;
 	}
@@ -116,7 +116,7 @@ function tc_preg( $preg, $file ) {
 				$pre = ( FALSE !== ( $pos = strpos( $this_line, $error ) ) ? substr( $this_line, 0, $pos ) : FALSE );
 			}
 			$pre = ltrim( htmlspecialchars( $pre ) );
-			$bad_lines .= "<pre class='tc-grep'>" . __("Line ", "theme-check") . ( $line_index+1 ) . ": " . $pre . htmlspecialchars( substr( stristr( $this_line, $error ), 0, 75 ) ) . "</pre>";
+			$bad_lines .= "<pre class='tc-grep'>" . __("Line", "theme-check") . ' ' . ( $line_index+1 ) . ": " . $pre . htmlspecialchars( substr( stristr( $this_line, $error ), 0, 75 ) ) . "</pre>";
 		}
 		$line_index++;
 

--- a/checks/badthings.php
+++ b/checks/badthings.php
@@ -9,10 +9,10 @@ class Bad_Checks implements themecheck {
 			'/(?<![_|a-z0-9|\.])eval\s?\(/i' => __( 'eval() is not allowed.', 'theme-check' ),
 			'/[^a-z0-9](?<!_)(popen|proc_open|[^_]exec|shell_exec|system|passthru)\(/' => __( 'PHP system calls are often disabled by server admins and should not be in themes', 'theme-check' ),
 			'/\s?ini_set\(/' => __( 'Themes should not change server PHP settings', 'theme-check' ),
-			'/base64_decode/' => __( 'base64_decode() is not allowed', 'theme-check' ),
-			'/base64_encode/' => __( 'base64_encode() is not allowed', 'theme-check' ),
-			'/uudecode/ims' => __( 'uudecode() is not allowed', 'theme-check' ),
-			'/str_rot13/ims' => __( 'str_rot13() is not allowed', 'theme-check' ),
+			'/base64_decode/' => sprintf( __( '%s is not allowed', 'theme-check' ), 'base64_decode()' ),
+			'/base64_encode/' => sprintf( __( '%s is not allowed', 'theme-check' ), 'base64_encode()' ),
+			'/uudecode/ims' => sprintf( __( '%s is not allowed', 'theme-check' ), 'uudecode()' ),
+			'/str_rot13/ims' => sprintf( __( '%s is not allowed', 'theme-check' ), 'str_rot13()' ),
 			'/cx=[0-9]{21}:[a-z0-9]{10}/' => __( 'Google search code detected', 'theme-check' ),
 			'/pub-[0-9]{16}/i' => __( 'Google advertising code detected', 'theme-check' )
 			);
@@ -45,7 +45,7 @@ class Bad_Checks implements themecheck {
 					$filename = tc_filename( $php_key );
 					$error = ltrim( rtrim( $matches[0],'(' ) );
 					$grep = tc_grep( $error, $php_key );
-					$this->error[] = sprintf(__('<span class="tc-lead tc-warning">WARNING</span>: Found <strong>%1$s</strong> in the file <strong>%2$s</strong>. %3$s.%4$s', 'theme-check'), $error, $filename, $check, $grep);
+					$this->error[] = sprintf('<span class="tc-lead tc-warning">'. __( 'WARNING', 'theme-check' ) . '</span>: ' . __( 'Found %1$s in the file %2$s. %3$s. %4$s', 'theme-check' ), '<strong>' . $error . '</strong>', '<strong>' . $filename . '</strong>', $check, $grep );
 					$ret = false;
 				}
 			}

--- a/checks/basic.php
+++ b/checks/basic.php
@@ -11,27 +11,27 @@ class Basic_Checks implements themecheck {
 		$ret = true;
 
 		$checks = array(
-			'DOCTYPE' => __( 'See: <a href="https://codex.wordpress.org/HTML_to_XHTML">https://codex.wordpress.org/HTML_to_XHTML</a><pre>&lt;!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"<br />"http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd"?&gt;</pre>', 'theme-check' ),
-			'wp_footer\s*\(' => __( 'See: <a href="https://codex.wordpress.org/Function_Reference/wp_footer">wp_footer</a><pre> &lt;?php wp_footer(); ?&gt;</pre>', 'theme-check' ),
-			'wp_head\s*\(' => __( 'See: <a href="https://codex.wordpress.org/Function_Reference/wp_head">wp_head</a><pre> &lt;?php wp_head(); ?&gt;</pre>', 'theme-check' ),
-			'language_attributes' => __( 'See: <a href="https://codex.wordpress.org/Function_Reference/language_attributes">language_attributes</a><pre>&lt;html &lt;?php language_attributes(); ?&gt;</pre>', 'theme-check' ),
+			'DOCTYPE' => sprintf( __( 'See: %s', 'theme-check' ), '<a href="https://codex.wordpress.org/HTML_to_XHTML">https://codex.wordpress.org/HTML_to_XHTML</a><pre> &lt;!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"<br />"http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd"?&gt;</pre>' ),
+			'wp_footer\s*\(' => sprintf( __( 'See: %s', 'theme-check' ), '<a href="https://codex.wordpress.org/Function_Reference/wp_footer">wp_footer</a><pre> &lt;?php wp_footer(); ?&gt;</pre>' ),
+			'wp_head\s*\(' => sprintf( __( 'See: %s', 'theme-check' ), '<a href="https://codex.wordpress.org/Function_Reference/wp_head">wp_head</a><pre> &lt;?php wp_head(); ?&gt;</pre>' ),
+			'language_attributes' => sprintf( __( 'See: %s', 'theme-check' ), '<a href="https://codex.wordpress.org/Function_Reference/language_attributes">language_attributes</a><pre> &lt;html &lt;?php language_attributes(); ?&gt;</pre>' ),
 			'charset' => __( 'There must be a charset defined in the Content-Type or the meta charset tag in the head.', 'theme-check' ),
-			'add_theme_support\s*\(\s?("|\')automatic-feed-links("|\')\s?\)' => __( 'See: <a href="https://codex.wordpress.org/Function_Reference/add_theme_support">add_theme_support</a><pre> &lt;?php add_theme_support( $feature ); ?&gt;</pre>', 'theme-check' ),
-			'comments_template\s*\(' => __( 'See: <a href="https://codex.wordpress.org/Template_Tags/comments_template">comments_template</a><pre> &lt;?php comments_template( $file, $separate_comments ); ?&gt;</pre>', 'theme-check' ),
-			'wp_list_comments\s*\(' => __( 'See: <a href="https://codex.wordpress.org/Template_Tags/wp_list_comments">wp_list_comments</a><pre> &lt;?php wp_list_comments( $args ); ?&gt;</pre>', 'theme-check' ),
-			'comment_form\s*\(' => __( 'See: <a href="https://codex.wordpress.org/Template_Tags/comment_form">comment_form</a><pre> &lt;?php comment_form(); ?&gt;</pre>', 'theme-check' ),
-			'body_class\s*\(' => __( 'See: <a href="https://codex.wordpress.org/Template_Tags/body_class">body_class</a><pre> &lt;?php body_class( $class ); ?&gt;</pre>', 'theme-check' ),
-			'wp_link_pages\s*\(' => __( 'See: <a href="https://codex.wordpress.org/Function_Reference/wp_link_pages">wp_link_pages</a><pre> &lt;?php wp_link_pages( $args ); ?&gt;</pre>', 'theme-check' ),
-			'post_class\s*\(' => __( 'See: <a href="https://codex.wordpress.org/Template_Tags/post_class">post_class</a><pre> &lt;div id="post-&lt;?php the_ID(); ?&gt;" &lt;?php post_class(); ?&gt;&gt;</pre>', 'theme-check' )
+			'add_theme_support\s*\(\s?("|\')automatic-feed-links("|\')\s?\)' => sprintf( __( 'See: %s', 'theme-check' ), '<a href="https://codex.wordpress.org/Function_Reference/add_theme_support">add_theme_support</a><pre> &lt;?php add_theme_support( $feature ); ?&gt;</pre>' ),
+			'comments_template\s*\(' => sprintf( __( 'See: %s', 'theme-check' ), '<a href="https://codex.wordpress.org/Template_Tags/comments_template">comments_template</a><pre> &lt;?php comments_template( $file, $separate_comments ); ?&gt;</pre>' ),
+			'wp_list_comments\s*\(' => sprintf( __( 'See: %s', 'theme-check' ), '<a href="https://codex.wordpress.org/Template_Tags/wp_list_comments">wp_list_comments</a><pre> &lt;?php wp_list_comments( $args ); ?&gt;</pre>' ),
+			'comment_form\s*\(' => sprintf( __( 'See: %s', 'theme-check' ), '<a href="https://codex.wordpress.org/Template_Tags/comment_form">comment_form</a><pre> &lt;?php comment_form(); ?&gt;</pre>' ),
+			'body_class\s*\(' => sprintf( __( 'See: %s', 'theme-check' ), '<a href="https://codex.wordpress.org/Template_Tags/body_class">body_class</a><pre> &lt;?php body_class( $class ); ?&gt;</pre>' ),
+			'wp_link_pages\s*\(' => sprintf( __( 'See: %s', 'theme-check' ), '<a href="https://codex.wordpress.org/Function_Reference/wp_link_pages">wp_link_pages</a><pre> &lt;?php wp_link_pages( $args ); ?&gt;</pre>' ),
+			'post_class\s*\(' => sprintf( __( 'See: %s', 'theme-check' ), '<a href="https://codex.wordpress.org/Template_Tags/post_class">post_class</a><pre> &lt;div id="post-&lt;?php the_ID(); ?&gt;" &lt;?php post_class(); ?&gt;&gt;</pre>' )
 			);
 
 		foreach ($checks as $key => $check) {
 			checkcount();
 			if ( !preg_match( '/' . $key . '/i', $php ) ) {
-				if ( $key === 'add_theme_support\s*\(\s?("|\')automatic-feed-links("|\')\s?\)' ) $key = __( 'add_theme_support( \'automatic-feed-links\' )', 'theme-check');
-				if ( $key === 'body_class\s*\(' ) $key = __( 'body_class call in body tag', 'theme-check');
+				if ( $key === 'add_theme_support\s*\(\s?("|\')automatic-feed-links("|\')\s?\)' ) $key = '<strong>add_theme_support( \'automatic-feed-links\' )</strong>';
+				if ( $key === 'body_class\s*\(' ) $key = sprintf( __( '%s call in body tag', 'theme-check'), '<strong>body_class</strong>' );
 				$key = str_replace( '\s*\(', '', $key );
-				$this->error[] = sprintf( '<span class="tc-lead tc-required">'.__('REQUIRED','theme-check').'</span>: '.__('Could not find %1$s. %2$s', 'theme-check' ), '<strong>' . $key . '</strong>', $check );
+				$this->error[] = sprintf( '<span class="tc-lead tc-required">'.__('REQUIRED','theme-check').'</span>: '.__('Could not find %s.', 'theme-check' ), $key ) . ' ' . $check ;
 				$ret = false;
 			}
 		}

--- a/checks/comment_reply.php
+++ b/checks/comment_reply.php
@@ -11,11 +11,11 @@ class Comment_Reply implements themecheck {
 
 		if ( ! preg_match( '/wp_enqueue_script\(\s?("|\')comment-reply("|\')/i', $php ) ) {
 			if ( ! preg_match( '/comment-reply/', $php ) ) {
-				$check = __( 'See: <a href="https://codex.wordpress.org/Migrating_Plugins_and_Themes_to_2.7/Enhanced_Comment_Display">Migrating Plugins and Themes to 2.7/Enhanced Comment Display</a><pre> &lt;?php if ( is_singular() ) wp_enqueue_script( "comment-reply" ); ?&gt;</pre>', 'theme-check' );
-				$this->error[] = sprintf('<span class="tc-lead tc-required">'.__('REQUIRED','theme-check').'</span>: '.__('Could not find the <strong>comment-reply</strong> script enqueued. %1$s', 'theme-check'), $check);
+				$check = sprintf( __( 'See: %s', 'theme-check' ), '<a href="https://codex.wordpress.org/Migrating_Plugins_and_Themes_to_2.7/Enhanced_Comment_Display">Migrating Plugins and Themes to 2.7/Enhanced Comment Display</a><pre> &lt;?php if ( is_singular() ) wp_enqueue_script( "comment-reply" ); ?&gt;</pre>' );
+				$this->error[] = sprintf('<span class="tc-lead tc-required">'.__('REQUIRED','theme-check').'</span>: '.__('Could not find the %s script enqueued.', 'theme-check'), '<strong>comment-reply</strong>' ).$check;
 				$ret = false;
 			} else {
-				$this->error[] = '<span class="tc-lead tc-info">'.__('INFO','theme-check').'</span>: '.__('Could not find the <strong>comment-reply</strong> script enqueued, however a reference to \'comment-reply\' was found. Make sure that the comment-reply script is being enqueued properly on singular pages.', 'theme-check');
+				$this->error[] = '<span class="tc-lead tc-info">'.__('INFO','theme-check').'</span>: '.sprintf(__('Could not find the %s script enqueued, however a reference to \'comment-reply\' was found. Make sure that the comment-reply script is being enqueued properly on singular pages.', 'theme-check'), '<strong>comment-reply</strong>');
 			}
 		}
 		return $ret;

--- a/checks/commpage.php
+++ b/checks/commpage.php
@@ -14,7 +14,7 @@ class CommentPaginationCheck implements themecheck {
 			strpos( $php, 'the_comments_pagination' ) === false &&
 		    (strpos( $php, 'next_comments_link' ) === false && strpos( $php, 'previous_comments_link' ) === false ) ) {
 
-			$this->error[] = '<span class="tc-lead tc-required">'.__('REQUIRED','theme-check').'</span>: '.__('The theme doesn\'t have comment pagination code in it. Use <strong>paginate_comments_links()</strong> or <strong>the_comments_navigation</strong> or <strong>the_comments_pagination</strong> or <strong>next_comments_link()</strong> and <strong>previous_comments_link()</strong> to add comment pagination.', 'theme-check' );
+			$this->error[] = '<span class="tc-lead tc-required">'.__('REQUIRED','theme-check').'</span>: '.sprintf( __('The theme doesn\'t have comment pagination code in it. Use %1$s or %2$s or %3$s or %4$s and %5$s to add comment pagination.', 'theme-check' ), '<strong>paginate_comments_links()</strong>', '<strong>the_comments_navigation</strong>', '<strong>the_comments_pagination</strong>', '<strong>next_comments_link()</strong>', '<strong>previous_comments_link()</strong>' );
 			$ret = false;
 		}
 

--- a/checks/constants.php
+++ b/checks/constants.php
@@ -21,7 +21,7 @@ class Constants implements themecheck {
 					$filename = tc_filename( $php_key );
 					$error = ltrim( rtrim( $matches[0], '(' ) );
 					$grep = tc_grep( $error, $php_key );
-					$this->error[] = sprintf('<span class="tc-lead tc-recommended">'.__('RECOMMENDED','theme-check').'</span>: '.__('%1$s was found in the file %2$s. Use %3$s instead.%4$s', 'theme-check'), '<strong>' . $error . '</strong>', '<strong>' . $filename . '</strong>', '<strong>' . $check . '</strong>', $grep );
+					$this->error[] = sprintf('<span class="tc-lead tc-recommended">'.__('RECOMMENDED','theme-check').'</span>: '.__('%1$s was found in the file %2$s.', 'theme-check'), '<strong>' . $error . '</strong>', '<strong>' . $filename . '</strong>').' '.sprintf( __('Use %s instead.', 'theme-check'), '<strong>' . $check . '</strong>'). $grep;
 				}
 			}
 		}

--- a/checks/content-width.php
+++ b/checks/content-width.php
@@ -11,7 +11,7 @@ class ContentWidthCheck implements themecheck {
 		$php = implode( ' ', $php_files );
 		checkcount();
 		if ( strpos( $php, '$content_width' ) === false && strpos( $php, '$GLOBALS' . "['content_width']" ) === false && !preg_match( '/add_filter\(\s?("|\')embed_defaults/', $php ) && !preg_match( '/add_filter\(\s?("|\')content_width/', $php ) ) {
-			$this->error[] = '<span class="tc-lead tc-required">'.__('REQUIRED','theme-check').'</span>: '.__('No content width has been defined. Example: <pre>if ( ! isset( $content_width ) ) $content_width = 900;</pre>', 'theme-check' );
+			$this->error[] = '<span class="tc-lead tc-required">'.__('REQUIRED','theme-check').'</span>: '.__('No content width has been defined.','theme-check').' '.sprintf( __('Example: %s','theme-check'), '<pre> if ( ! isset( $content_width ) ) $content_width = 900;</pre>' );
 			$ret = false;
 		}
 

--- a/checks/customs.php
+++ b/checks/customs.php
@@ -11,11 +11,11 @@ class CustomCheck implements themecheck {
 		checkcount();
 
 		if ( ! preg_match( '#add_theme_support\s?\(\s?[\'|"]custom-header#', $php ) ) {
-			$this->error[] = '<span class="tc-lead tc-recommended">'.__('RECOMMENDED','theme-check').'</span>: '.__('No reference to <strong>add_theme_support( "custom-header", $args )</strong> was found in the theme. It is recommended that the theme implement this functionality if using an image for the header.', 'theme-check' );
+			$this->error[] = '<span class="tc-lead tc-recommended">'.__('RECOMMENDED','theme-check').'</span>: '.sprintf( __( 'No reference to %s was found in the theme.', 'theme-check'), '<strong>add_theme_support( "custom-header", $args )</strong>' ).' '.__( 'It is recommended that the theme implement this functionality if using an image for the header.', 'theme-check' );
 		}
 
 		if ( ! preg_match( '#add_theme_support\s?\(\s?[\'|"]custom-background#', $php ) ) {
-			$this->error[] = '<span class="tc-lead tc-recommended">'.__('RECOMMENDED','theme-check').'</span>: '.__('No reference to <strong>add_theme_support( "custom-background", $args )</strong> was found in the theme. If the theme uses background images or solid colors for the background, then it is recommended that the theme implement this functionality.', 'theme-check' );
+			$this->error[] = '<span class="tc-lead tc-recommended">'.__('RECOMMENDED','theme-check').'</span>: '.sprintf( __( 'No reference to %s was found in the theme.', 'theme-check'), '<strong>add_theme_support( "custom-background", $args )</strong>' ).' '.__( 'If the theme uses background images or solid colors for the background, then it is recommended that the theme implement this functionality.', 'theme-check' );
 		}
 
 		return $ret;

--- a/checks/dep_recommend.php
+++ b/checks/dep_recommend.php
@@ -40,9 +40,11 @@ class Deprecated_Recommended implements themecheck {
 
 					// Point out the deprecated function.
 					$error_msg = sprintf(
-						__( '%1$s found in the file %2$s. Deprecated since version %3$s.', 'theme-check' ),
+						__( '%1$s was found in the file %2$s.', 'theme-check' ),
 						'<strong>' . $error . '()</strong>',
-						'<strong>' . $filename . '</strong>',
+						'<strong>' . $filename . '</strong>')
+					. ' ' . sprintf(
+						__( 'Deprecated since version %s.', 'theme-check' ),
 						'<strong>' . $version . '</strong>'
 					);
 

--- a/checks/deprecated.php
+++ b/checks/deprecated.php
@@ -268,9 +268,11 @@ class Deprecated implements themecheck {
 
 					// Point out the deprecated function.
 					$error_msg = sprintf(
-						__( '%1$s found in the file %2$s. Deprecated since version %3$s.', 'theme-check' ),
+						__( '%1$s was found in the file %2$s.', 'theme-check' ),
 						'<strong>' . $error . '()</strong>',
-						'<strong>' . $filename . '</strong>',
+						'<strong>' . $filename . '</strong>')
+					. ' ' . sprintf(
+						__( 'Deprecated since version %s.', 'theme-check' ),
 						'<strong>' . $version . '</strong>'
 					);
 

--- a/checks/editorstyle.php
+++ b/checks/editorstyle.php
@@ -10,7 +10,7 @@ class EditorStyleCheck implements themecheck {
 		$php = implode( ' ', $php_files );
 
 		if ( strpos( $php, 'add_editor_style' ) === false ) {
-			$this->error[] = '<span class="tc-lead tc-recommended">'.__('RECOMMENDED','theme-check').'</span>: '.__('No reference to <strong>add_editor_style()</strong> was found in the theme. It is recommended that the theme implement editor styling, so as to make the editor content match the resulting post output in the theme, for a better user experience.', 'theme-check' );
+			$this->error[] = '<span class="tc-lead tc-recommended">'.__('RECOMMENDED','theme-check').'</span>: '.sprintf( __( 'No reference to %s was found in the theme.', 'theme-check'), '<strong>add_editor_style()</strong>' ).' '.__( 'It is recommended that the theme implement editor styling, so as to make the editor content match the resulting post output in the theme, for a better user experience.', 'theme-check' );
 		}
 
 		return $ret;

--- a/checks/filenames.php
+++ b/checks/filenames.php
@@ -19,7 +19,7 @@ class File_Checks implements themecheck {
 		}
 		$blacklist = array(
 				'thumbs.db'				=> __( 'Windows thumbnail store', 'theme-check' ),
-				'desktop.ini'			=> __( 'windows system file', 'theme-check' ),
+				'desktop.ini'			=> __( 'Windows system file', 'theme-check' ),
 				'project.properties'	=> __( 'NetBeans Project File', 'theme-check' ),
 				'project.xml'			=> __( 'NetBeans Project File', 'theme-check' ),
 				'\.kpf'					=> __( 'Komodo Project File', 'theme-check' ),
@@ -55,7 +55,7 @@ class File_Checks implements themecheck {
 
 		foreach( $rechave as $file => $reason ) {
 			if ( !in_array( $file, $filenames ) ) {
-				$this->error[] = sprintf('<span class="tc-lead tc-recommended">'.__('RECOMMENDED','theme-check').'</span>: '.__('Could not find the file %1$s in the theme. %2$s', 'theme-check'), '<strong>' . $file . '</strong>', $reason );
+				$this->error[] = sprintf('<span class="tc-lead tc-recommended">'.__('RECOMMENDED','theme-check').'</span>: '.__('Could not find the file %s in the theme.', 'theme-check'), '<strong>' . $file . '</strong>' ) . $reason ;
 			}
 		}
 

--- a/checks/i18n.php
+++ b/checks/i18n.php
@@ -49,11 +49,11 @@ class I18NCheck implements themecheck {
 							if ( isset( $line[0] ) ) {
 								$error = ( !strpos( $error, $line[0] ) ) ? $grep : '';
 							}
-							$this->error[] = sprintf('<span class="tc-lead tc-recommended">'.__('RECOMMENDED','theme-check').'</span>: '.__('Possible variable %1$s found in translation function in %2$s. Translation function calls must NOT contain PHP variables. %3$s','theme-check'),
+							$this->error[] = sprintf('<span class="tc-lead tc-recommended">'.__('RECOMMENDED','theme-check').'</span>: '.__('Possible variable %1$s found in translation function in %2$s. Translation function calls must NOT contain PHP variables.','theme-check'),
 								'<strong>' . $token[1] . '</strong>',
-								'<strong>' . $filename . '</strong>',
-								$error
-							);
+								'<strong>' . $filename . '</strong>')
+								. $error
+							;
 							break; // stop looking at the tokens on this line once a variable is found
 						}
 					}

--- a/checks/iframes.php
+++ b/checks/iframes.php
@@ -6,7 +6,7 @@ class IframeCheck implements themecheck {
 		$ret = true;
 
 		$checks = array(
-			'/<(iframe)[^>]*>/' => __( 'iframes are sometimes used to load unwanted adverts and code on your site', 'theme-check' )
+			'/<(iframe)[^>]*>/' => __( 'iframes are sometimes used to load unwanted adverts and code on your site.', 'theme-check' )
 			);
 
 		foreach ( $php_files as $php_key => $phpfile ) {
@@ -17,7 +17,7 @@ class IframeCheck implements themecheck {
 					$error = ltrim( $matches[1], '(' );
 					$error = rtrim( $error, '(' );
 					$grep = tc_grep( $error, $php_key );
-					$this->error[] = sprintf('<span class="tc-lead tc-info">'.__('INFO','theme-check').'</span>: '.__('%1$s was found in the file %2$s %3$s.%4$s', 'theme-check'), '<strong>' . $error . '</strong>', '<strong>' . $filename . '</strong>', $check, $grep ) ;
+					$this->error[] = sprintf('<span class="tc-lead tc-info">'.__('INFO','theme-check').'</span>: '.__('%1$s was found in the file %2$s.', 'theme-check'), '<strong>' . $error . '</strong>', '<strong>' . $filename . '</strong>') .' '. $check . $grep;
 				}
 			}
 		}

--- a/checks/include.php
+++ b/checks/include.php
@@ -7,7 +7,7 @@ class IncludeCheck implements themecheck {
 
 		$ret = true;
 
-		$checks = array( '/(?<![a-z0-9_])(?:requir|includ)e(?:_once)?\s?[\'"\(]/' => __( 'The theme appears to use include or require. If these are being used to include separate sections of a template from independent files, then <strong>get_template_part()</strong> should be used instead.', 'theme-check' ) );
+		$checks = array( '/(?<![a-z0-9_])(?:requir|includ)e(?:_once)?\s?[\'"\(]/' => sprintf( __( 'The theme appears to use %1$s or %2$s. If these are being used to include separate sections of a template from independent files, then %3$s should be used instead.', 'theme-check' ), '<strong>include</strong>', '<strong>require</strong>', '<strong>get_template_part()</strong>' ) );
 
 		foreach ( $php_files as $php_key => $phpfile ) {
 			foreach ( $checks as $key => $check ) {
@@ -16,7 +16,7 @@ class IncludeCheck implements themecheck {
 					$filename = tc_filename( $php_key );
 					$error = '/(?<![a-z0-9_])(?:requir|includ)e(?:_once)?\s?[\'"\(]/';
 					$grep = tc_preg( $error, $php_key );
-					if ( basename($filename) !== 'functions.php' ) $this->error[] = sprintf ( '<span class="tc-lead tc-info">'.__('INFO','theme-check').'</span>: '.__('%1$s %2$s %3$s', 'theme-check' ), '<strong>' . $filename . '</strong>', $check, $grep );
+					if ( basename($filename) !== 'functions.php' ) $this->error[] = sprintf ( '<span class="tc-lead tc-info">'.__('INFO','theme-check').'</span>: '.__( '%1$s was found in the file %2$s.', 'theme-check'), '<strong>require</strong>/<strong>include</strong>', '<strong>' . $filename . '</strong>') . ' ' . $check . $grep ;
 				}
 			}
 

--- a/checks/links.php
+++ b/checks/links.php
@@ -23,7 +23,7 @@ class Check_Links implements themecheck {
 					}
 				}
 				if ( $grep ) {
-					$this->error[] = sprintf('<span class="tc-lead tc-info">'.__('INFO','theme-check').'</span>: '.__('Possible hard-coded links were found in the file %1$s.%2$s', 'theme-check'), '<strong>' . $filename . '</strong>', $grep);
+					$this->error[] = sprintf('<span class="tc-lead tc-info">'.__('INFO','theme-check').'</span>: '.__('Possible hard-coded links were found in the file %1$s.', 'theme-check'), '<strong>' . $filename . '</strong>' ) . $grep;
 				}
 			}
 		}

--- a/checks/malware.php
+++ b/checks/malware.php
@@ -20,7 +20,7 @@ class MalwareCheck implements themecheck {
 							$error = ltrim( $match, '(' );
 							$error = rtrim( $error, '(' );
 							$grep = tc_grep( $error, $php_key );
-							$this->error[] = sprintf('<span class="tc-lead tc-warning">'.__('WARNING','theme-check').'</span>: '.__('%1$s was found in the file %2$s %3$s.%4$s', 'theme-check'), '<strong>' . $error. '</strong>', '<strong>' . $filename . '</strong>', $check, $grep );
+							$this->error[] = sprintf('<span class="tc-lead tc-warning">'.__('WARNING','theme-check').'</span>: '.__('%1$s was found in the file %2$s.', 'theme-check'), '<strong>' . $error . '</strong>', '<strong>' . $filename . '</strong>').' '.sprintf( __('Use %s instead.', 'theme-check'), '<strong>' . $check . '</strong>'). $grep;
 							$ret = false;
 						}
 				}

--- a/checks/more_deprecated.php
+++ b/checks/more_deprecated.php
@@ -49,7 +49,7 @@ class More_Deprecated implements themecheck {
 						$filename      = tc_filename( $php_key );
 						$error         = ltrim( rtrim( $matches[0], '(' ) );
 						$grep          = tc_grep( $error, $php_key );
-						$this->error[] = sprintf( '<span class="tc-lead tc-required">' . __( 'REQUIRED', 'theme-check' ) . '</span>: ' . __( '%1$s was found in the file %2$s. Use %3$s instead.%4$s', 'theme-check' ), '<strong>' . $error . '</strong>', '<strong>' . $filename . '</strong>', '<strong>' . $replacement . '</strong>', $grep );
+						$this->error[] = sprintf( '<span class="tc-lead tc-required">' . __( 'REQUIRED', 'theme-check' ) . '</span>: ' . __('%1$s was found in the file %2$s.', 'theme-check'), '<strong>' . $error . '</strong>', '<strong>' . $filename . '</strong>').' '.sprintf( __('Use %s instead.', 'theme-check'), '<strong>' . $replacement . '</strong>'). $grep;
 						$ret           = false;
 					}
 				}

--- a/checks/navmenu.php
+++ b/checks/navmenu.php
@@ -11,7 +11,7 @@ class NavMenuCheck implements themecheck {
 		$php = implode( ' ', $php_files );
 		checkcount();
 		if ( strpos( $php, 'nav_menu' ) === false ) {
-			$this->error[] = '<span class="tc-lead tc-recommended">'.__('RECOMMENDED','theme-check').'</span>: '.__("No reference to nav_menu's was found in the theme. Note that if your theme has a menu bar, it is required to use the WordPress nav_menu functionality for it.", 'theme-check' );
+			$this->error[] = '<span class="tc-lead tc-recommended">'.__('RECOMMENDED','theme-check').'</span>: '.sprintf( __( 'No reference to %s was found in the theme.', 'theme-check'), '<strong>nav_menu</strong>' ).' '.sprintf(__( 'Note that if your theme has a menu bar, it is required to use the WordPress %s functionality for it.', 'theme-check' ), '<strong>nav_menu</strong>' );
 		}
 
 		return $ret;

--- a/checks/nonprintable.php
+++ b/checks/nonprintable.php
@@ -13,7 +13,7 @@ class NonPrintableCheck implements themecheck {
 			if ( preg_match('/[\x00-\x08\x0B-\x0C\x0E-\x1F\x80-\xFF]/', $content, $matches ) ) {
 				$filename = tc_filename( $name );
 				$non_print = tc_preg( '/[\x00-\x08\x0B-\x0C\x0E-\x1F\x80-\xFF]/', $name );
-				$this->error[] = sprintf('<span class="tc-lead tc-info">'.__('INFO','theme-check').'</span>: '.__('Non-printable characters were found in the %1$s file. You may want to check this file for errors.%2$s', 'theme-check'), '<strong>' . $filename . '</strong>', $non_print);
+				$this->error[] = sprintf('<span class="tc-lead tc-info">'.__('INFO','theme-check').'</span>: '.__('Non-printable characters were found in the %s file. You may want to check this file for errors.', 'theme-check'), '<strong>' . $filename . '</strong>' ) . $non_print;
 			}
 		}
 

--- a/checks/phpshort.php
+++ b/checks/phpshort.php
@@ -11,7 +11,7 @@ class PHPShortTagsCheck implements themecheck {
 			if ( preg_match( '/<\?(\=?)(?!php|xml)/i', $phpfile ) ) {
 				$filename = tc_filename( $php_key );
 				$grep = tc_preg( '/<\?(\=?)(?!php|xml)/', $php_key );
-				$this->error[] = sprintf('<span class="tc-lead tc-warning">'.__('WARNING','theme-check').'</span>: '.__('Found PHP short tags in file %1$s.%2$s', 'theme-check'), '<strong>' . $filename . '</strong>', $grep);
+				$this->error[] = sprintf('<span class="tc-lead tc-warning">'.__('WARNING','theme-check').'</span>: '.__('Found PHP short tags in file %s.', 'theme-check'), '<strong>' . $filename . '</strong>' ). $grep;
 				$ret = false;
 			}
 		}

--- a/checks/post-formats.php
+++ b/checks/post-formats.php
@@ -24,7 +24,7 @@ class PostFormatCheck implements themecheck {
 						$matches[0] = str_replace(array('"',"'"),'', $matches[0]);
 						$error = esc_html( rtrim($matches[0], '(' ) );
 						$grep = tc_grep( rtrim($matches[0], '(' ), $php_key);
-						$this->error[] = sprintf('<span class="tc-lead tc-required">'.__('REQUIRED','theme-check').'</span>: '.__('%1$s was found in the file %2$s. However get_post_format and/or has_post_format were not found, and no use of formats in the CSS was detected.', 'theme-check'), '<strong>' . $error . '</strong>', '<strong>' . $filename . '</strong>');
+						$this->error[] = '<span class="tc-lead tc-required">'.__('REQUIRED','theme-check').'</span>: '.sprintf( __('%1$s was found in the file %2$s.', 'theme-check'), '<strong>' . $error . '</strong>', '<strong>' . $filename . '</strong>' ).' '.sprintf( __('However %1$s and/or %2$s were not found, and no use of formats in the CSS was detected.', 'theme-check'), '<strong>get_post_format</strong>', '<strong>has_post_format</strong>' );
 						$ret = false;
 					}
 				}

--- a/checks/postsnav.php
+++ b/checks/postsnav.php
@@ -16,7 +16,7 @@ class PostPaginationCheck implements themecheck {
 		     strpos( $php, 'the_posts_navigation' ) === false &&
 		   ( strpos( $php, 'previous_posts_link' ) === false && strpos( $php, 'next_posts_link' ) === false )
 		   ) {
-			$this->error[] = '<span class="tc-lead tc-required">'.__('REQUIRED','theme-check').'</span>: '.__("The theme doesn't have post pagination code in it. Use <strong>posts_nav_link()</strong> or <strong>paginate_links()</strong> or <strong>the_posts_pagination()</strong> or <strong>the_posts_navigation()</strong> or <strong>next_posts_link()</strong> and <strong>previous_posts_link()</strong> to add post pagination.", 'theme-check' );
+			$this->error[] = '<span class="tc-lead tc-required">'.__('REQUIRED','theme-check').'</span>: '.sprintf( __('The theme doesn\'t have post pagination code in it. Use %1$s or %2$s or %3$s or %4$s or %5$s and %6$s to add post pagination.', 'theme-check' ), '<strong>posts_nav_link()</strong>', '<strong>paginate_links()</strong>', '<strong>the_posts_pagination()</strong>', '<strong>the_posts_navigation()</strong>', '<strong>next_posts_link()</strong>', '<strong>previous_posts_link()</strong>' );
 			$ret = false;
 		}
 

--- a/checks/postthumb.php
+++ b/checks/postthumb.php
@@ -12,11 +12,11 @@ class PostThumbnailCheck implements themecheck {
 		checkcount();
 
 		if ( strpos( $php, 'the_post_thumbnail' ) === false ) {
-			$this->error[] = '<span class="tc-lead tc-recommended">'.__('RECOMMENDED','theme-check').'</span>: '.__('No reference to <strong>the_post_thumbnail()</strong> was found in the theme. It is recommended that the theme implement this functionality instead of using custom fields for thumbnails.', 'theme-check' );
+			$this->error[] = '<span class="tc-lead tc-recommended">'.__('RECOMMENDED','theme-check').'</span>: '.sprintf( __( 'No reference to %s was found in the theme.', 'theme-check'), '<strong>the_post_thumbnail()</strong>' ).' '.__( 'It is recommended that the theme implement this functionality instead of using custom fields for thumbnails.', 'theme-check' );
 		}
 
 		if ( strpos( $php, 'post-thumbnails' ) === false ) {
-			$this->error[] = '<span class="tc-lead tc-recommended">'.__('RECOMMENDED','theme-check').'</span>: '.__('No reference to post-thumbnails was found in the theme. If the theme has a thumbnail like functionality, it should be implemented with <strong>add_theme_support( "post-thumbnails" )</strong>in the functions.php file.', 'theme-check' );
+			$this->error[] = '<span class="tc-lead tc-recommended">'.__('RECOMMENDED','theme-check').'</span>: '.sprintf( __( 'No reference to %s was found in the theme.', 'theme-check'), '<strong>post-thumbnails</strong>' ).' '.sprintf( __( 'If the theme has a thumbnail like functionality, it should be implemented with %s in the functions.php file.', 'theme-check' ), '<strong>add_theme_support( "post-thumbnails" )</strong>' );
 		}
 
 		return $ret;

--- a/checks/required.php
+++ b/checks/required.php
@@ -19,7 +19,7 @@ class Required implements themecheck {
 					$matches[0] = str_replace(array('"',"'"),'', $matches[0]);
 					$error = esc_html( rtrim($matches[0], '(' ) );
 					$grep = tc_grep( rtrim($matches[0], '(' ), $php_key );
-					$this->error[] = sprintf('<span class="tc-lead tc-required">'.__('REQUIRED','theme-check').'</span>: '.__('%1$s was found in the file %2$s. Use %3$s instead.%4$s', 'theme-check'), '<strong>' . $error . '</strong>', '<strong>' . $filename . '</strong>', '<strong>' . $check . '</strong>', $grep);
+					$this->error[] = sprintf('<span class="tc-lead tc-required">'.__('REQUIRED','theme-check').'</span>: '.__('%1$s was found in the file %2$s.', 'theme-check'), '<strong>' . $error . '</strong>', '<strong>' . $filename . '</strong>').' '.sprintf( __('Use %s instead.', 'theme-check'), '<strong>' . $check . '</strong>'). $grep;
 					$ret = false;
 				}
 			}

--- a/checks/searchform.php
+++ b/checks/searchform.php
@@ -6,14 +6,14 @@ class SearchFormCheck implements themecheck {
 	function check( $php_files, $css_files, $other_files ) {
 
 		$ret = true;
-		$checks = array( '/(include\s?\(\s?TEMPLATEPATH\s?\.?\s?["|\']\/searchform.php["|\']\s?\))/' => __( 'Please use <strong>get_search_form()</strong> instead of including searchform.php directly.', 'theme-check' ) );
+		$checks = array( '/(include\s?\(\s?TEMPLATEPATH\s?\.?\s?["|\']\/searchform.php["|\']\s?\))/' => sprintf( __( 'Use %1$s instead of including %2$s directly.', 'theme-check' ), '<strong>get_search_form()</strong>', '<strong>searchform.php</strong>' ) );
 		foreach ( $php_files as $php_key => $phpfile ) {
 			foreach ($checks as $key => $check) {
 				checkcount();
 				if ( preg_match( $key, $phpfile, $out ) ) {
 					$grep = tc_preg( $key, $php_key );
 					$filename = tc_filename( $php_key );
-					$this->error[] = sprintf('<span class="tc-lead tc-required">'.__('REQUIRED','theme-check').'</span>: '.__('%1$s %2$s%3$s', 'theme-check'), '<strong>' . $filename . '</strong>', $check, $grep);
+					$this->error[] = sprintf( '<span class="tc-lead tc-required">'.__('REQUIRED','theme-check').'</span>: '.__( '%1$s was found in the file %2$s.', 'theme-check'), '<strong>searchform.php</strong>', '<strong>' . $filename . '</strong>') . ' '. $check . $grep;
 					$ret = false;
 				}
 			}

--- a/checks/style_needed.php
+++ b/checks/style_needed.php
@@ -8,27 +8,27 @@ class Style_Needed implements themecheck {
 		$ret = true;
 
 		$checks = array(
-			'[ \t\/*#]*Theme Name:' => __( '<strong>Theme name:</strong> is missing from your style.css header.', 'theme-check' ),
-			'[ \t\/*#]*Description:' => __( '<strong>Description:</strong> is missing from your style.css header.', 'theme-check' ),
-			'[ \t\/*#]*Author:' => __( '<strong>Author:</strong> is missing from your style.css header.', 'theme-check' ),
-			'[ \t\/*#]*Version' => __( '<strong>Version:</strong> is missing from your style.css header.', 'theme-check' ),
-			'[ \t\/*#]*License:' => __( '<strong>License:</strong> is missing from your style.css header.', 'theme-check' ),
-			'[ \t\/*#]*License URI:' => __( '<strong>License URI:</strong> is missing from your style.css header.', 'theme-check' ),
-			'\.sticky' => __( '<strong>.sticky</strong> css class is needed in your theme css.', 'theme-check' ),
-			'\.bypostauthor' => __( '<strong>.bypostauthor</strong> css class is needed in your theme css.', 'theme-check' ),
-			'\.alignleft' => __( '<strong>.alignleft</strong> css class is needed in your theme css.', 'theme-check' ),
-			'\.alignright' => __( '<strong>.alignright</strong> css class is needed in your theme css.', 'theme-check' ),
-			'\.aligncenter' => __( '<strong>.aligncenter</strong> css class is needed in your theme css.', 'theme-check' ),
-			'\.wp-caption' => __( '<strong>.wp-caption</strong> css class is needed in your theme css.', 'theme-check' ),
-			'\.wp-caption-text' => __( '<strong>.wp-caption-text</strong> css class is needed in your theme css.', 'theme-check' ),
-			'\.gallery-caption' => __( '<strong>.gallery-caption</strong> css class is needed in your theme css.', 'theme-check' ),
-			'\.screen-reader-text' => __( '<strong>.screen-reader-text</strong> css class is needed in your theme css. See See: <a href="http://codex.wordpress.org/CSS#WordPress_Generated_Classes">the Codex</a> for an example implementation.', 'theme-check' )
+			'[ \t\/*#]*Theme Name:' => 	sprintf( __( '%s is missing from your style.css header.', 'theme-check' ), '<strong>Theme name:</strong>' ),
+			'[ \t\/*#]*Description:' => sprintf( __( '%s is missing from your style.css header.', 'theme-check' ), '<strong>Description:</strong>' ),
+			'[ \t\/*#]*Author:' => 		sprintf( __( '%s is missing from your style.css header.', 'theme-check' ), '<strong>Author:</strong>' ),
+			'[ \t\/*#]*Version' => 		sprintf( __( '%s is missing from your style.css header.', 'theme-check' ), '<strong>Version:</strong>' ),
+			'[ \t\/*#]*License:' => 	sprintf( __( '%s is missing from your style.css header.', 'theme-check' ), '<strong>License:</strong>' ),
+			'[ \t\/*#]*License URI:' => sprintf( __( '%s is missing from your style.css header.', 'theme-check' ), '<strong>License URI:</strong>' ),
+			'\.sticky' => 				sprintf( __( '%s css class is needed in your theme css.', 'theme-check' ), '<strong>.sticky</strong>' ),
+			'\.bypostauthor' => 		sprintf( __( '%s css class is needed in your theme css.', 'theme-check' ), '<strong>.bypostauthor</strong>' ),
+			'\.alignleft' => 			sprintf( __( '%s css class is needed in your theme css.', 'theme-check' ), '<strong>.alignleft</strong>' ),
+			'\.alignright' => 			sprintf( __( '%s css class is needed in your theme css.', 'theme-check' ), '<strong>.alignright</strong>' ),
+			'\.aligncenter' => 			sprintf( __( '%s css class is needed in your theme css.', 'theme-check' ), '<strong>.aligncenter</strong>' ),
+			'\.wp-caption' => 			sprintf( __( '%s css class is needed in your theme css.', 'theme-check' ), '<strong>.wp-caption</strong>' ),
+			'\.wp-caption-text' => 		sprintf( __( '%s css class is needed in your theme css.', 'theme-check' ), '<strong>.wp-caption-text</strong>' ),
+			'\.gallery-caption' => 		sprintf( __( '%s css class is needed in your theme css.', 'theme-check' ), '<strong>.gallery-caption</strong>' ),
+			'\.screen-reader-text' => 	sprintf( __( '%s css class is needed in your theme css.', 'theme-check' ),  '<strong>.screen-reader-text</strong>' ) . ' ' . __('See <a href="http://codex.wordpress.org/CSS#WordPress_Generated_Classes">the Codex</a> for an example implementation.', 'theme-check' )
 		);
 
 		foreach ($checks as $key => $check) {
 			checkcount();
 			if ( !preg_match( '/' . $key . '/i', $css, $matches ) ) {
-				$this->error[] = "<span class='tc-lead tc-required'>" . __('REQUIRED', 'theme-check' ) . "</span>:" . $check;
+				$this->error[] = "<span class='tc-lead tc-required'>" . __('REQUIRED', 'theme-check' ) . "</span>: " . $check;
 				$ret = false;
 			}
 		}

--- a/checks/style_tags.php
+++ b/checks/style_tags.php
@@ -13,7 +13,7 @@ class Style_Tags implements themecheck {
 		}
 
 		if ( !$data[ 'Tags' ] ) {
-			$this->error[] = '<span class="tc-lead tc-recommended">' . __('RECOMMENDED','theme-check') . '</span>: ' . __( '<strong>Tags:</strong> is either empty or missing in style.css header.', 'theme-check' );
+			$this->error[] = '<span class="tc-lead tc-recommended">' . __('RECOMMENDED','theme-check') . '</span>: ' . sprintf( __( '%s is either empty or missing in style.css header.', 'theme-check' ), '<strong>Tags:</strong>' );
 			return $ret;
 		}
 
@@ -22,12 +22,12 @@ class Style_Tags implements themecheck {
 		foreach( $data[ 'Tags' ] as $tag ) {
 
 			if ( strpos( strtolower( $tag ), "accessibility-ready") !== false ) {
-				$this->error[] = '<span class="tc-lead tc-info">'. __('INFO','theme-check'). '</span>: ' . __( 'Themes that use the tag accessibility-ready will need to undergo an accessibility review.','theme-check' ) . ' ' . __('See <a href="https://make.wordpress.org/themes/handbook/review/accessibility/">https://make.wordpress.org/themes/handbook/review/accessibility/</a>', 'theme-check' );
+				$this->error[] = '<span class="tc-lead tc-info">'. __('INFO','theme-check'). '</span>: ' . __( 'Themes that use the tag accessibility-ready will need to undergo an accessibility review.','theme-check' ) . ' ' . sprintf( __('See: %s', 'theme-check' ) , '<a href="https://make.wordpress.org/themes/handbook/review/accessibility/">https://make.wordpress.org/themes/handbook/review/accessibility/</a>' );
 			}
 
 			if ( !in_array( strtolower( $tag ), $allowed_tags ) ) {
 				if ( in_array( strtolower( $tag ), array("flexible-width","fixed-width") ) ) {
-					$this->error[] = '<span class="tc-lead tc-warning">'. __('WARNING','theme-check'). '</span>: ' . __( 'The flexible-width and fixed-width tags changed to fluid-layout and fixed-layout tags in WordPress 3.8. Additionally, the responsive-layout tag was added. Please change to using one of the new tags.', 'theme-check' );
+					$this->error[] = '<span class="tc-lead tc-warning">'. __('WARNING','theme-check'). '</span>: ' . sprintf( __( 'The %1$s and %2$s tags changed to %3$s and %4$s tags in WordPress 3.8. Additionally, the %5$s tag was added. Please change to using one of the new tags.', 'theme-check' ), '<strong>flexible-width</strong>', '<strong>fixed-width</strong>', '<strong>fluid-layout</strong>', '<strong>fixed-layout</strong>', '<strong>responsive-layout</strong>' );
 				} else {
 					$this->error[] = '<span class="tc-lead tc-warning">'. __('WARNING','theme-check'). '</span>: ' . sprintf( __('Found wrong tag, remove %s from your style.css header.', 'theme-check'), '<strong>' . $tag . '</strong>' );
 					$ret = false;

--- a/checks/suggested.php
+++ b/checks/suggested.php
@@ -31,7 +31,7 @@ class Suggested implements themecheck {
 					$matches[0] = str_replace(array('"',"'"),'', $matches[0]);
 					$error = trim( esc_html( rtrim($matches[0], '(' ) ) );
 					$grep = tc_grep( rtrim( $matches[0], '(' ), $php_key );
-					$this->error[] = sprintf('<span class="tc-lead tc-recommended">' . __( 'RECOMMENDED', 'theme-check' ) . '</span>: '. __( '%1$s was found in the file %2$s. Use %3$s instead.%4$s', 'theme-check'), '<strong>' . $error . '</strong>', '<strong>' . $filename . '</strong>', '<strong>' . $check . '</strong>', $grep);
+					$this->error[] = sprintf('<span class="tc-lead tc-recommended">' . __( 'RECOMMENDED', 'theme-check' ) . '</span>: '. __('%1$s was found in the file %2$s.', 'theme-check'), '<strong>' . $error . '</strong>', '<strong>' . $filename . '</strong>').' '.sprintf( __('Use %s instead.', 'theme-check'), '<strong>' . $check . '</strong>'). $grep;
 				}
 			}
 		}

--- a/checks/title.php
+++ b/checks/title.php
@@ -17,21 +17,21 @@ class Title_Checks implements themecheck {
 		// Look for add_theme_support( 'title-tag' ) first
 		$titletag = true;
 		if ( ! preg_match( '#add_theme_support\s?\(\s?[\'|"]title-tag#', $php ) ) {
-			$this->error[] = '<span class="tc-lead tc-recommended">'.__('RECOMMENDED','theme-check').'</span>: '.__('No reference to <strong>add_theme_support( "title-tag" )</strong> was found in the theme. It is recommended that the theme implement this functionality for WordPress 4.1 and above.', 'theme-check' );
+			$this->error[] = '<span class="tc-lead tc-recommended">'.__('RECOMMENDED','theme-check').'</span>: '.sprintf( __( 'No reference to %s was found in the theme.', 'theme-check'), '<strong>add_theme_support( "title-tag" )</strong>' ).' '.__( 'It is recommended that the theme implement this functionality for WordPress 4.1 and above.', 'theme-check' );
 			$titletag = false;
 		}
 		
 		// Look for <title> and </title> tags.
 		checkcount();
 		if ( ( false === strpos( $php, '<title>' ) || false === strpos( $php, '</title>' ) ) && !$titletag  ) {
-			$this->error[] = '<span class="tc-lead tc-required">' . __( 'REQUIRED', 'theme-check').'</span>: ' . __( 'The theme needs to have <strong>&lt;title&gt;</strong> tags, ideally in the <strong>header.php</strong> file.', 'theme-check' );
+			$this->error[] = '<span class="tc-lead tc-required">' . __( 'REQUIRED', 'theme-check').'</span>: ' . sprintf( __( 'The theme needs to have %1$s tags, ideally in the %2$s file.', 'theme-check' ), '<strong>&lt;title&gt;</strong>', '<strong>header.php</strong>' );
 			$ret = false;
 		}
 
 		// Check whether there is a call to wp_title()
 		checkcount();
 		if ( false === strpos( $php, 'wp_title(' ) && !$titletag ) {
-			$this->error[] = '<span class="tc-lead tc-required">' . __( 'REQUIRED', 'theme-check').'</span>: ' . __( 'The theme needs to have a call to <strong>wp_title()</strong>, ideally in the <strong>header.php</strong> file.', 'theme-check' );
+			$this->error[] = '<span class="tc-lead tc-required">' . __( 'REQUIRED', 'theme-check').'</span>: ' . sprintf( __( 'The theme needs to have a call to %1$s, ideally in the %2$s file.', 'theme-check' ), '<strong>wp_title()</strong>', '<strong>header.php</strong>' );
 			$ret = false;
 		}
 
@@ -45,7 +45,7 @@ class Title_Checks implements themecheck {
 			// First looks ahead to see of there's <title>...</title>
 			// Then performs a negative look ahead for <title> wp_title(...); </title>
 			if ( preg_match( '/(?=<title>(.*)<\/title>)(?!<title>\s*<\?php\s*wp_title\([^\)]*\);?\s*\?>\s*<\/title>)/s', $file_content ) ) {
-				$this->error[] = '<span class="tc-lead tc-required">' . __( 'REQUIRED', 'theme-check').'</span>: ' . __( 'The <strong>&lt;title&gt;</strong> tags can only contain a call to <strong>wp_title()</strong>. Use the  <strong>wp_title filter</strong> to modify the output', 'theme-check' );
+			$this->error[] = '<span class="tc-lead tc-required">' . __( 'REQUIRED', 'theme-check').'</span>: ' . sprintf( __( 'The %1$s tags can only contain a call to %2$s. Use the %3$s filter to modify the output.', 'theme-check' ), '<strong>&lt;title&gt;</strong>', '<strong>wp_title()</strong>', '<strong>wp_title</strong>' );
 				$ret = false;
 			}
 		}

--- a/checks/uri.php
+++ b/checks/uri.php
@@ -12,13 +12,13 @@ class Check_URI implements themecheck {
 		if ( !empty( $data['AuthorURI'] ) && !empty( $data['URI'] ) ) {
 
 			if ( strtolower( preg_replace('/https?:\/\/|www./i', '', trim( $data['URI'] , '/' ) ) ) == strtolower( preg_replace('/https?:\/\/|www./i', '', trim( $data['AuthorURI'], '/' ) ) ) )  {
-				$this->error[] = __('<span class="tc-lead tc-required">'.__('REQUIRED','theme-check').'</span>: '.__('Your Theme URI and Author URI should not be the same.', 'theme-check') );
+				$this->error[] = '<span class="tc-lead tc-required">'.__('REQUIRED','theme-check').'</span>: '.__('Your Theme URI and Author URI should not be the same.', 'theme-check');
 				$ret = false;
 			}
 	
 			//We allow .org user profiles as Author URI, so only check the Theme URI. We also allow WordPress.com links.
 			if ( stripos( $data['URI'], 'wordpress.org' ) && $data[ 'AuthorName' ] <> "the WordPress team" || stripos( $data['URI'], 'w.org' ) && $data[ 'AuthorName' ] <> "the WordPress team" ) {
-				$this->error[] .= __('<span class="tc-lead tc-required">'.__('REQUIRED','theme-check').'</span>: '.__('Using a WordPress.org Theme URI is reserved for official themes.', 'theme-check') );
+				$this->error[] .= '<span class="tc-lead tc-required">'.__('REQUIRED','theme-check').'</span>: '.__('Using a WordPress.org Theme URI is reserved for official themes.', 'theme-check');
 				$ret = false;
 			}
 		}

--- a/checks/widgets.php
+++ b/checks/widgets.php
@@ -18,12 +18,12 @@ class WidgetsCheck implements themecheck {
 		}
 
 		if ( strpos( $php, 'register_sidebar' ) !== false && strpos( $php, 'dynamic_sidebar' ) === false ) {
-			$this->error[] = "<span class='tc-lead tc-required'>" . __( "REQUIRED", 'theme-check') . '</span>: '. __( "The theme appears to use <strong>register_sidebar()</strong> but no <strong>dynamic_sidebar()</strong> was found. See: <a href='https://codex.wordpress.org/Function_Reference/dynamic_sidebar'>dynamic_sidebar</a><pre> &lt;?php dynamic_sidebar( \$index ); ?&gt;</pre>", "theme-check" );
+			$this->error[] = "<span class='tc-lead tc-required'>" . __( "REQUIRED", 'theme-check') . '</span>: '. sprintf( __( 'The theme appears to use %1$s but no %2$s was found.', 'theme-check' ), '<strong>register_sidebar()</strong>', '<strong>dynamic_sidebar()</strong>' ) . " " . sprintf( __( "See: %s", "theme-check" ), '<a href="https://codex.wordpress.org/Function_Reference/dynamic_sidebar">dynamic_sidebar</a><pre> &lt;?php dynamic_sidebar( \$index ); ?&gt;</pre>' );
 			$ret = false;
 		}
 
 		if ( strpos( $php, 'register_sidebar' ) === false && strpos( $php, 'dynamic_sidebar' ) !== false ) {
-			$this->error[] = "<span class='tc-lead tc-required'>" . __( "REQUIRED", 'theme-check') . '</span>: '. __( "The theme appears to use <strong>dynamic_sidebars()</strong> but no <strong>register_sidebar()</strong> was found. See: <a href='https://codex.wordpress.org/Function_Reference/register_sidebar'>register_sidebar</a><pre> &lt;?php register_sidebar( \$args ); ?&gt;</pre>", "theme-check" );
+			$this->error[] = "<span class='tc-lead tc-required'>" . __( "REQUIRED", 'theme-check') . '</span>: '. sprintf( __( 'The theme appears to use %1$s but no %2$s was found.', 'theme-check' ), '<strong>dynamic_sidebar()</strong>', '<strong>register_sidebar()</strong>' ) . " " . sprintf( __( "See: %s", "theme-check" ), '<a href="https://codex.wordpress.org/Function_Reference/register_sidebar">register_sidebar</a><pre> &lt;?php register_sidebar( \$args ); ?&gt;</pre>' );
 			$ret = false;
 		}
 
@@ -31,7 +31,7 @@ class WidgetsCheck implements themecheck {
 		 * There are widgets registered, is the widgets_init action present?
 		 */
 		if ( strpos( $php, 'register_sidebar' ) !== false && preg_match( '/add_action\s*\(\s*("|\')widgets_init("|\')\s*,/', $php ) == false ) {
-			$this->error[] = "<span class='tc-lead tc-required'>" . __( "REQUIRED", 'theme-check') . '</span>: '. sprintf( __( "Sidebars need to be registered in a custom function hooked to the <strong>widgets_init</strong> action. See: %s.", "theme-check" ), '<a href="https://codex.wordpress.org/Function_Reference/register_sidebar">register_sidebar()</a>' );
+			$this->error[] = "<span class='tc-lead tc-required'>" . __( "REQUIRED", 'theme-check') . '</span>: '. __( "Sidebars need to be registered in a custom function hooked to the <strong>widgets_init</strong> action.", "theme-check" ) . " " . sprintf( __( "See: %s", "theme-check" ), '<a href="https://codex.wordpress.org/Function_Reference/register_sidebar">register_sidebar()</a>.' );
 			$ret = false;
 		}
 		return $ret;

--- a/checks/worms.php
+++ b/checks/worms.php
@@ -7,10 +7,10 @@ class WormCheck implements themecheck {
 		$php_files = array_merge( $php_files, $other_files );
 		$checks = array(
 			'/wshell\.php/'=> __( 'This may be a script used by hackers to get control of your server!', 'theme-check' ),
-			'/ShellBOT/' => __( 'This may be a script used by hackers to get control of your server', 'theme-check' ),
+			'/ShellBOT/' => __( 'This may be a script used by hackers to get control of your server!', 'theme-check' ),
 			'/uname -a/' => __( 'Tells a hacker what operating system your server is running', 'theme-check' ),
-			'/php \$[a-zA-Z]*=\'as\';/' => __( 'Symptom of the "Pharma Hack" <a href="http://blog.sucuri.net/2010/07/understanding-and-cleaning-the-pharma-hack-on-wordpress.html">[1]</a>', 'theme-check' ),
-			'/defined?\(\'wp_class_support/' => __( 'Symptom of the "Pharma Hack" <a href="http://blog.sucuri.net/2010/07/understanding-and-cleaning-the-pharma-hack-on-wordpress.html">[1]</a>', 'theme-check' ),
+			'/php \$[a-zA-Z]*=\'as\';/' => __( 'Symptom of the "Pharma Hack"', 'theme-check' ) . ' <a href="http://blog.sucuri.net/2010/07/understanding-and-cleaning-the-pharma-hack-on-wordpress.html">[1]</a>',
+			'/defined?\(\'wp_class_support/' => __( 'Symptom of the "Pharma Hack"', 'theme-check' ) . ' <a href="http://blog.sucuri.net/2010/07/understanding-and-cleaning-the-pharma-hack-on-wordpress.html">[1]</a>',
 			);
 
 		foreach ( $php_files as $php_key => $phpfile ) {

--- a/main.php
+++ b/main.php
@@ -79,7 +79,7 @@ function check_main( $theme ) {
 		$plugins = get_plugins( '/theme-check' );
 		$version = explode( '.', $plugins['theme-check.php']['Version'] );
 		echo '<p>' . sprintf(
-			__(' Running %1$s tests against %2$s using Guidelines Version: %3$s Plugin revision: %4$s', 'theme-check'),
+			__('Running %1$s tests against %2$s using Guidelines Version: %3$s Plugin revision: %4$s', 'theme-check'),
 			'<strong>' . $checkcount . '</strong>',
 			'<strong>' . $data[ 'Title' ] . '</strong>',
 			'<strong>' . $version[0] . '</strong>',
@@ -142,7 +142,7 @@ function tc_intro() {
 
 function tc_success() {
 	?>
-	<div class="tc-success"><p><?php _e( 'Now your theme has passed the basic tests you need to check it properly using the test data before you upload to the WordPress Themes Directory.', 'theme-check' ); ?></p>
+	<div class="tc-success"><p><?php _e( 'Now that your theme has passed the basic tests you need to check it properly using the test data before you upload to the WordPress Themes Directory.', 'theme-check' ); ?></p>
 	<p><?php _e( 'Make sure to review the guidelines at <a href="https://codex.wordpress.org/Theme_Review">Theme Review</a> before uploading a Theme.', 'theme-check' ); ?></p>
 	<h3><?php _e( 'Codex Links', 'theme-check' ); ?></h3>
 	<ul>


### PR DESCRIPTION
Remove non traslatable names from strings and transformed in variables.

Examples of removal: function_names() (and `<strong>`tags`</strong>`), links, html code like `<span class="tc-lead tc-warning">` , `<pre>code</code>`. reutilization of same strings and avoiding recundancy, crop out from the end of translation strings the variable that just renders the actual error list (ex. `$error`, `$grep`, etc),

This will avoid errors of information lost in translation for sensitive information like function names etc, reduce dramatically the number of strings with reapeated data (from 182 to 147!), makes strings easier to understand and translate.
General uniformization and simplification of translatable strings

Most of these changes won't make any changes in the final report shown, except those with small typos and those that were uniformized due to very small differences, for the better user experience.

A lot were similar, and some just reused the same sentences over and over, as the sensitive data was croped out as a variable outside of the string, huge ammount of similar strings obtained.

I did this as I've translated the plugin, so I checked it for coherence and usability.
