### PR TITLE
Make text domain checks stricter

### DIFF
--- a/checks/textdomain.php
+++ b/checks/textdomain.php
@@ -135,7 +135,7 @@ class TextDomainCheck implements themecheck {
 		$domainscount = count($domains);
 		
 		if ( $domainscount > 1 ) {
-			$this->error[] = '<span class="tc-lead tc-info">' . __( 'INFO', 'theme-check' ) . '</span>: ' 
+			$this->error[] = '<span class="tc-lead tc-warning">' . __( 'Warning', 'theme-check' ) . '</span>: ' 
 			. __( 'More than one text-domain is being used in this theme. This means the theme will not be compatible with WordPress.org language packs.', 'theme-check' )
 			. '<br>'
 			. sprintf( __( 'The domains found are %s', 'theme-check'), '<strong>' . $domainlist . '</strong>' );
@@ -145,6 +145,10 @@ class TextDomainCheck implements themecheck {
 			. '<br>'
 			. sprintf( __( 'The domain found is %s', 'theme-check'), '<strong>' . $domainlist . '</strong>' );
 			
+		}
+
+		if ( $domainscount > 2 ) {
+			$ret = false;
 		}
 		
 		return $ret;

--- a/checks/textdomain.php
+++ b/checks/textdomain.php
@@ -26,23 +26,13 @@ class TextDomainCheck implements themecheck {
 		'esc_html_x' => array('string', 'context', 'domain'),
 		'comments_number_link' => array('string', 'singular', 'plural', 'domain'),
 	);
-	
+
 	// core names their themes differently
 	var $exceptions = array( 'twentyten',  'twentyeleven',  'twentytwelve',  'twentythirteen',  'twentyfourteen',  'twentyfifteen',  'twentysixteen',  'twentyseventeen',  'twentyeighteen',  'twentynineteen',  'twentytwenty'  );
 
 	function check( $php_files, $css_files, $other_files ) {
 		global $data, $themename;
-		
-		// ignore core themes and uploads on w.org for this one check
-		if ( !in_array($themename, $this->exceptions) && !defined( 'WPORGPATH' ) ) {
-			$correct_domain = sanitize_title_with_dashes($data['Name']);
-			if ( $themename != $correct_domain ) {
-				$this->error[] = '<span class="tc-lead tc-warning">' . __( 'WARNING', 'theme-check' ) . '</span>: ' 
-					. sprintf ( __( "Your theme appears to be in the wrong directory for the theme name. The directory name must match the slug of the theme. This theme's correct slug and text-domain is %s.", 'theme-check' ), '<strong>' . $correct_domain . '</strong>' ).
-					'<br>'. __( '(If this is a child theme, you can ignore this error.)' , 'theme-check' );
-			}
-		}
-		
+
 		$ret = true;
 		$error = '';
 		checkcount();
@@ -53,15 +43,15 @@ class TextDomainCheck implements themecheck {
 		}
 
 		$funcs = array_keys($this->rules);
-		
+
 		$domains = array();
-		
+
 		foreach ( $php_files as $php_key => $phpfile ) {
 			$error='';
-			
+
 			// tokenize the file
 			$tokens = token_get_all($phpfile);
-			
+
 			$in_func = false;
 			$args_started = false;
 			$parens_balance = 0;
@@ -69,7 +59,7 @@ class TextDomainCheck implements themecheck {
 
 			foreach($tokens as $token) {
 				$string_success = false;
-				
+
 				if (is_array($token)) {
 					list($id, $text) = $token;
 					if (T_STRING == $id && in_array($text, $funcs)) {
@@ -84,9 +74,9 @@ class TextDomainCheck implements themecheck {
 								// avoid a warning when too many arguments are in a function, cause a fail case
 								$new_args = $args;
 								$new_args[] = $text;
-								$this->error[] = '<span class="tc-lead tc-warning">' . __( 'WARNING', 'theme-check' ) . '</span>: ' 
+								$this->error[] = '<span class="tc-lead tc-warning">' . __( 'WARNING', 'theme-check' ) . '</span>: '
 								. sprintf (
-									__( 'Found a translation function that has an incorrect number of arguments. Function %1$s, with the arguments %2$s', 'theme-check' ), 
+									__( 'Found a translation function that has an incorrect number of arguments. Function %1$s, with the arguments %2$s', 'theme-check' ),
 									'<strong>' . $func . '</strong>',
 									'<strong>' . implode(', ',$new_args) . '</strong>'
 								);
@@ -114,10 +104,10 @@ class TextDomainCheck implements themecheck {
 					--$parens_balance;
 					if ($in_func && 0 == $parens_balance) {
 						if (!$found_domain) {
-							$this->error[] = '<span class="tc-lead tc-warning">' . __( 'WARNING', 'theme-check' ) . '</span>: ' 
+							$this->error[] = '<span class="tc-lead tc-warning">' . __( 'WARNING', 'theme-check' ) . '</span>: '
 							. sprintf (
-								__( 'Found a translation function that is missing a text-domain. Function %1$s, with the arguments %2$s', 'theme-check' ), 
-								'<strong>' . $func . '</strong>', 
+								__( 'Found a translation function that is missing a text-domain. Function %1$s, with the arguments %2$s', 'theme-check' ),
+								'<strong>' . $func . '</strong>',
 								'<strong>' . implode(', ',$args) . '</strong>'
 							);
 						}
@@ -129,28 +119,43 @@ class TextDomainCheck implements themecheck {
 				}
 			}
 		}
-		
+
 		$domains = array_unique($domains);
 		$domainlist = implode( ', ', $domains );
 		$domainscount = count($domains);
-		
+
+		// ignore core themes and uploads on w.org for this one check
+		if ( !in_array($themename, $this->exceptions) ) {
+			$correct_domain = sanitize_title_with_dashes($data['Name']);
+			if ( $themename != $correct_domain && ! defined( 'WPORGPATH' ) ) {
+				$this->error[] = '<span class="tc-lead tc-warning">' . __( 'WARNING', 'theme-check' ) . '</span>: ' 
+				. sprintf ( __( "Your theme appears to be in the wrong directory for the theme name. The directory name must match the slug of the theme. This theme's correct slug and text-domain is %s.", 'theme-check' ), '<strong>' . $correct_domain . '</strong>' ).
+				'<br>'. __( '(If this is a child theme, you can ignore this error.)' , 'theme-check' );
+			} elseif ( ! in_array( $correct_domain, $domains ) ) {
+				$this->error[] = '<span class="tc-lead tc-required">' . __( 'REQUIRED', 'theme-check' ) . '</span>: ' 
+				. sprintf ( __( "This theme text domain does not match the theme's slug. The text domain used: %s", 'theme-check' ), '<strong>' . $domainlist . '</strong>' )
+				. sprintf ( __( "This theme's correct slug and text-domain is %s.", 'theme-check' ), '<strong>' . $correct_domain . '</strong>' );
+				$ret = false;
+			}
+		}
+
 		if ( $domainscount > 1 ) {
-			$this->error[] = '<span class="tc-lead tc-warning">' . __( 'Warning', 'theme-check' ) . '</span>: ' 
+			$this->error[] = '<span class="tc-lead tc-warning">' . __( 'Warning', 'theme-check' ) . '</span>: '
 			. __( 'More than one text-domain is being used in this theme. This means the theme will not be compatible with WordPress.org language packs.', 'theme-check' )
 			. '<br>'
 			. sprintf( __( 'The domains found are %s', 'theme-check'), '<strong>' . $domainlist . '</strong>' );
 		} else {
-			$this->error[] = '<span class="tc-lead tc-info">' . __( 'INFO', 'theme-check' ) . '</span>: ' 
+			$this->error[] = '<span class="tc-lead tc-info">' . __( 'INFO', 'theme-check' ) . '</span>: '
 			. __( "Only one text-domain is being used in this theme. Make sure it matches the theme's slug correctly so that the theme will be compatible with WordPress.org language packs.", 'theme-check' )
 			. '<br>'
 			. sprintf( __( 'The domain found is %s', 'theme-check'), '<strong>' . $domainlist . '</strong>' );
-			
+
 		}
 
 		if ( $domainscount > 2 ) {
 			$ret = false;
 		}
-		
+
 		return $ret;
 	}
 


### PR DESCRIPTION
As the TRT Requirement allows a maximum to two text domain, the check should fail if there are more than 2 text domains.

Now there is also a check that the correct text domain is used so to make use of langauge packs