### PR TITLE
Title tag check changes

### DIFF
--- a/checks/title.php
+++ b/checks/title.php
@@ -13,14 +13,15 @@ class Title_Checks implements themecheck {
 	function check( $php_files, $css_files, $other_files ) {
 		$ret = true;
 		$php = implode( ' ', $php_files );
-		
+
 		// Look for add_theme_support( 'title-tag' ) first
 		$titletag = true;
 		if ( ! preg_match( '#add_theme_support\s?\(\s?[\'|"]title-tag#', $php ) ) {
-			$this->error[] = '<span class="tc-lead tc-recommended">'.__('RECOMMENDED','theme-check').'</span>: '.__('No reference to <strong>add_theme_support( "title-tag" )</strong> was found in the theme. It is recommended that the theme implement this functionality for WordPress 4.1 and above.', 'theme-check' );
+			$this->error[] = '<span class="tc-lead tc-required">'.__('REQUIRED','theme-check').'</span>: '.__('No reference to <strong>add_theme_support( "title-tag" )</strong> was found in the theme.', 'theme-check' );
 			$titletag = false;
+			$ret = false;
 		}
-		
+
 		// Look for <title> and </title> tags.
 		checkcount();
 		if ( ( false === strpos( $php, '<title>' ) || false === strpos( $php, '</title>' ) ) && !$titletag  ) {
@@ -41,7 +42,7 @@ class Title_Checks implements themecheck {
 		foreach ( $php_files as $file_path => $file_content ) {
 			// Look for anything that looks like <svg>...</svg> and exclude it (inline svg's have titles too)
 			$file_content = preg_replace('/<svg>.*<\/svg>/s', '', $file_content);
-			
+
 			// First looks ahead to see of there's <title>...</title>
 			// Then performs a negative look ahead for <title> wp_title(...); </title>
 			if ( preg_match( '/(?=<title>(.*)<\/title>)(?!<title>\s*<\?php\s*wp_title\([^\)]*\);?\s*\?>\s*<\/title>)/s', $file_content ) ) {

--- a/checks/title.php
+++ b/checks/title.php
@@ -24,15 +24,15 @@ class Title_Checks implements themecheck {
 
 		// Look for <title> and </title> tags.
 		checkcount();
-		if ( ( false === strpos( $php, '<title>' ) || false === strpos( $php, '</title>' ) ) && !$titletag  ) {
-			$this->error[] = '<span class="tc-lead tc-required">' . __( 'REQUIRED', 'theme-check').'</span>: ' . __( 'The theme needs to have <strong>&lt;title&gt;</strong> tags, ideally in the <strong>header.php</strong> file.', 'theme-check' );
+		if ( ( 0 <= strpos( $php, '<title>' ) || 0 <= strpos( $php, '</title>' ) ) && !$titletag  ) {
+			$this->error[] = '<span class="tc-lead tc-required">' . __( 'REQUIRED', 'theme-check').'</span>: ' . __( 'The theme must not used the <strong>&lt;title&gt;</strong> tags.', 'theme-check' );
 			$ret = false;
 		}
 
 		// Check whether there is a call to wp_title()
 		checkcount();
-		if ( false === strpos( $php, 'wp_title(' ) && !$titletag ) {
-			$this->error[] = '<span class="tc-lead tc-required">' . __( 'REQUIRED', 'theme-check').'</span>: ' . __( 'The theme needs to have a call to <strong>wp_title()</strong>, ideally in the <strong>header.php</strong> file.', 'theme-check' );
+		if ( 0 <= strpos( $php, 'wp_title(' ) && !$titletag ) {
+			$this->error[] = '<span class="tc-lead tc-required">' . __( 'REQUIRED', 'theme-check').'</span>: ' . __( 'The theme must not call to <strong>wp_title()</strong>.', 'theme-check' );
 			$ret = false;
 		}
 

--- a/checks/title.php
+++ b/checks/title.php
@@ -41,7 +41,7 @@ class Title_Checks implements themecheck {
 
 		foreach ( $php_files as $file_path => $file_content ) {
 			// Look for anything that looks like <svg>...</svg> and exclude it (inline svg's have titles too)
-			$file_content = preg_replace('/<svg>.*<\/svg>/s', '', $file_content);
+			$file_content = preg_replace('/<svg.*>.*<\/svg>/s', '', $file_content);
 
 			// First looks ahead to see of there's <title>...</title>
 			// Then performs a negative look ahead for <title> wp_title(...); </title>


### PR DESCRIPTION
This PR makes the use of `add_theme_support('title-tag')` required and not just recommended as it was released in WP 4.1 in December 2014.

This also changes from `<title>` tags and `wp_title()` being required to not allowed as `add_theme_support('title-tag')` has been added. `wp_title()` was nearly deprecated. http://wptavern.com/wordpress-4-4-to-deprecate-the-wp_title-function